### PR TITLE
[WIP] Add Global Energy Monitor Data Script

### DIFF
--- a/data/global_energy_monitor.py
+++ b/data/global_energy_monitor.py
@@ -10,6 +10,8 @@ Gas: https://globalenergymonitor.org/projects/global-gas-plant-tracker/
 Solar: https://globalenergymonitor.org/projects/global-solar-power-tracker/
 Wind: https://globalenergymonitor.org/projects/global-wind-power-tracker/
 
+Changes in Coal Tracker: https://drive.google.com/drive/folders/1kbLck8dEWlqUifv98AHNgL3KA_wMf1nL?usp=sharing
+
 """
 
 solar_data = pd.read_excel("Global-Solar-Power-Tracker-May-2022.xlsx", sheet_name=None)

--- a/data/global_energy_monitor.py
+++ b/data/global_energy_monitor.py
@@ -1,6 +1,17 @@
 import pandas as pd
 import numpy as np
 
+"""
+
+Data is available from:
+
+Coal: https://globalenergymonitor.org/projects/global-coal-plant-tracker/
+Gas: https://globalenergymonitor.org/projects/global-gas-plant-tracker/
+Solar: https://globalenergymonitor.org/projects/global-solar-power-tracker/
+Wind: https://globalenergymonitor.org/projects/global-wind-power-tracker/
+
+"""
+
 solar_data = pd.read_excel("Global-Solar-Power-Tracker-May-2022.xlsx", sheet_name=None)
 solar_data = solar_data['Data']
 wind_data = pd.read_excel("Global-Wind-Power-Tracker-May-2022.xlsx", sheet_name=None)
@@ -69,13 +80,13 @@ def extract_and_format_wind_solar(solar, wind):
     ).reset_index()
     return solar, grouped_solar, wind, grouped_wind
 
-solar, groupd_solar, wind, grouped_wind = extract_and_format_wind_solar(solar_data, wind_data)
+solar, grouped_solar, wind, grouped_wind = extract_and_format_wind_solar(solar_data, wind_data)
 gas, grouped_gas = extract_and_format_gas(gas_data)
 coal, grouped_coal = extract_and_format_coal(coal_data)
 
 # Combine on region name the MW generation by type
 from functools import reduce
-combined_grouped = reduce(lambda x,y: pd.merge(x,y, on=['State/Province', 'Status', 'Start year'], how='outer'), [groupd_solar, grouped_wind, grouped_coal, grouped_gas])
+combined_grouped = reduce(lambda x,y: pd.merge(x,y, on=['State/Province', 'Status', 'Start year'], how='outer'), [grouped_solar, grouped_wind, grouped_coal, grouped_gas])
 combined_grouped["sum_capacity_mw"] = combined_grouped['sum_gas_capacity_mw'].fillna(0.) + combined_grouped['sum_coal_capacity_mw'].fillna(0.) + combined_grouped['sum_solar_capacity_mw'].fillna(0.) + combined_grouped['sum_wind_capacity_mw'].fillna(0.)
 
 # Now need to know per year what the percentage is, not the start year, but for all ones after start year, and operational, what is percentage then

--- a/data/global_energy_monitor.py
+++ b/data/global_energy_monitor.py
@@ -1,0 +1,105 @@
+import pandas as pd
+import numpy as np
+
+solar_data = pd.read_excel("Global-Solar-Power-Tracker-May-2022.xlsx", sheet_name=None)
+solar_data = solar_data['Data']
+wind_data = pd.read_excel("Global-Wind-Power-Tracker-May-2022.xlsx", sheet_name=None)
+wind_data = wind_data['Data']
+gas_data = pd.read_excel("Global-Gas-Plant-Tracker-Aug-2022.xlsx", sheet_name=None)
+coal_data = pd.read_excel("Global-Coal-Plant-Tracker-July-2022.xlsx", sheet_name=None)
+
+"""
+Things to extract and put in database:
+Context: 
+Fraction of energy from Coal per region
+Fraction of energy from Gas per region
+
+Action:
+Proposed Transition To (%):
+- Solar
+- Wind
+- Gas
+
+For Q1-4 data summary -> Also have it do more fine grained (per month?) as well
+
+For quarterly data -> line of region (large region) with number of plants of each type and total generating capacity
+Same for future, proposed number of plants and generating capacity for the next quarters as appropriate
+For region, and (subnational unit, State/Province, as they are the same it seems), and Country
+Include coal-to-gas conversion/replacement in there as well
+ 
+"""
+
+def extract_and_format_gas(gas):
+    drop_columns = ['Wiki URL', 'Wiki URL local language',
+       'Plant name (local script)', 'Owner', 'Parent', 'Other IDs (location)',
+       'Other IDs (unit)', 'Other plant names', 'Captive [heat, power, both]',
+       'Captive industry type',
+       'Captive non-industry use [heat, power, both, none]',
+       'GEM location ID',
+       'GEM unit ID']
+    gas = gas['Gas plants - data'].drop(columns=drop_columns).fillna({"Coal-to-gas conversion/replacement?": "Unknown", "CCS attachment?": "Unknown", "Hydrogen capable?": "Unknown"}).rename(columns={"Subnational unit (province, state)": "State/Province"})
+    grouped_gas = gas.groupby(["State/Province", 'Start year', 'Fuel', 'Status', 'Coal-to-gas conversion/replacement?', 'CCS attachment?', 'Hydrogen capable?']).agg(
+        sum_gas_capacity_mw=('Capacity elec. (MW)', 'sum'),
+    ).reset_index()
+    return gas, grouped_gas
+
+def extract_and_format_coal(coal):
+    drop_columns = ['Tracker ID', 'TrackerLOC', 'ParentID', 'Wiki page', 'Chinese Name',
+       'Other names', 'Owner', 'Parent', 'Permits', 'Captive', 'Captive industry use',
+       'Captive residential use', 'Heat rate (Btu per kWh)', 'Capacity factor',]
+
+    coal = coal['Units'].drop(columns=drop_columns).fillna({"Coal type": "Unknown"}).rename(columns={"Subnational unit (province, state)": "State/Province", "Year": "Start year"})
+    grouped_coal = coal.groupby(
+        ['State/Province','Start year', 'Coal type', 'Status']).agg(
+        sum_coal_capacity_mw=('Capacity (MW)', 'sum'),
+    ).reset_index()
+    return coal, grouped_coal
+
+def extract_and_format_wind_solar(solar, wind):
+    drop_columns = ["Project Name in Local Language / Script", "Operator", "Operator Name in Local Language / Script",
+                    "Owner Name in Local Language / Script", "Owner", "GEM phase ID", "GEM location ID", "Wiki URL",
+                    "Other IDs (location)", "Other IDs (unit/phase)", "Other Name(s)"]
+    solar = solar.drop(columns=drop_columns)
+    wind = wind.drop(columns=drop_columns)
+    grouped_solar = solar.groupby(['State/Province','Start year', 'Status']).agg(
+        sum_solar_capacity_mw=('Capacity (MW)', 'sum'),
+    ).reset_index()
+    grouped_wind = wind.groupby(['State/Province','Start year', 'Status']).agg(
+        sum_wind_capacity_mw=('Capacity (MW)', 'sum'),
+    ).reset_index()
+    return solar, grouped_solar, wind, grouped_wind
+
+solar, groupd_solar, wind, grouped_wind = extract_and_format_wind_solar(solar_data, wind_data)
+gas, grouped_gas = extract_and_format_gas(gas_data)
+coal, grouped_coal = extract_and_format_coal(coal_data)
+
+# Combine on region name the MW generation by type
+from functools import reduce
+combined_grouped = reduce(lambda x,y: pd.merge(x,y, on=['State/Province', 'Status', 'Start year'], how='outer'), [groupd_solar, grouped_wind, grouped_coal, grouped_gas])
+combined_grouped["sum_capacity_mw"] = combined_grouped['sum_gas_capacity_mw'].fillna(0.) + combined_grouped['sum_coal_capacity_mw'].fillna(0.) + combined_grouped['sum_solar_capacity_mw'].fillna(0.) + combined_grouped['sum_wind_capacity_mw'].fillna(0.)
+
+# Now need to know per year what the percentage is, not the start year, but for all ones after start year, and operational, what is percentage then
+
+combined_grouped["percentage_mw_gas"] = combined_grouped['sum_gas_capacity_mw'].fillna(0.) / combined_grouped["sum_capacity_mw"]
+combined_grouped["percentage_mw_coal"] = combined_grouped['sum_coal_capacity_mw'].fillna(0.) / combined_grouped["sum_capacity_mw"]
+combined_grouped["percentage_mw_wind"] = combined_grouped['sum_wind_capacity_mw'].fillna(0.) / combined_grouped["sum_capacity_mw"]
+combined_grouped["percentage_mw_solar"] = combined_grouped['sum_solar_capacity_mw'].fillna(0.) / combined_grouped["sum_capacity_mw"]
+
+print(combined_grouped)
+print(combined_grouped.columns)
+
+grouped_production = combined_grouped.groupby(['State/Province', 'Status']).agg(
+        region_mw_gas_total=('sum_gas_capacity_mw', np.nansum),
+        region_mw_coal_total=('sum_coal_capacity_mw', np.nansum),
+        region_mw_wind_total=('sum_wind_capacity_mw', np.nansum),
+        region_mw_solar_total=('sum_solar_capacity_mw', np.nansum),
+    ).reset_index()
+
+grouped_production["region_total_mw"] = grouped_production['region_mw_gas_total'].fillna(0.) + grouped_production['region_mw_coal_total'].fillna(0.) + grouped_production['region_mw_wind_total'].fillna(0.) + grouped_production['region_mw_solar_total'].fillna(0.)
+
+grouped_production["percentage_mw_gas"] = grouped_production['region_mw_gas_total'].fillna(0.) / grouped_production["region_total_mw"]
+grouped_production["percentage_mw_coal"] = grouped_production['region_mw_coal_total'].fillna(0.) / grouped_production["region_total_mw"]
+grouped_production["percentage_mw_wind"] = grouped_production['region_mw_wind_total'].fillna(0.) / grouped_production["region_total_mw"]
+grouped_production["percentage_mw_solar"] = grouped_production['region_mw_solar_total'].fillna(0.) / grouped_production["region_total_mw"]
+
+selected_production = grouped_production[(grouped_production['percentage_mw_wind'] > 0) & (grouped_production['percentage_mw_solar'] > 0) & (grouped_production['percentage_mw_gas'] > 0)].dropna()


### PR DESCRIPTION
This PR would add a script to process four Global Energy Monitor trackers for wind, solar, gas, and coal into the Project Resilience format. 

Opening this PR now to get some feedback on how the data should be structured. This tracker data is mostly yearly, and while it is probably possible to scrape the months of different power plants' start years from the linked GEM wiki, but I think that's outside the scope of this right now. 

For regions, I chose Sate/Province level as its subnational, but not getting too fine-grained. GEM data goes down to individual cities, and lat/lon coordinates, so depending how specific we want to be, we should be able to get it from this dataset.

Data is available from the following:

Coal: https://globalenergymonitor.org/projects/global-coal-plant-tracker/
Gas: https://globalenergymonitor.org/projects/global-gas-plant-tracker/
Solar: https://globalenergymonitor.org/projects/global-solar-power-tracker/
Wind: https://globalenergymonitor.org/projects/global-wind-power-tracker/