### PR TITLE
Fix oecd tariffs

### DIFF
--- a/data/oecd/oecd_tariffs.ipynb
+++ b/data/oecd/oecd_tariffs.ipynb
@@ -126,28 +126,27 @@
     "path_to_country_conversion_table = os.path.join(metadata_dir, \"country_name_conversion.csv\")\n",
     "missing_countries = []\n",
     "if not os.path.exists(path_to_country_conversion_table):\n",
-    "  # get world bank country names and iso alpha3 code\n",
-    "  countries_table = pd.read_csv('../worldbank/processed/ccdr.csv')\n",
-    "  countries_table = countries_table[['country_code','country_name']].drop_duplicates().reset_index(drop=True)\n",
-    "  countries_table.columns = ['country_code',\t'wb_country_name']\n",
+    "    # get world bank country names and iso alpha3 code\n",
+    "    countries_table = pd.read_csv('../worldbank/processed/ccdr.csv')\n",
+    "    countries_table = countries_table[['country_code','country_name']].drop_duplicates().reset_index(drop=True)\n",
+    "    countries_table.columns = ['country_code',\t'wb_country_name']\n",
     "\n",
-    "  # get oecd country names\n",
-    "  # oecd_country_names = pd.read_csv('processed/fit.csv')\n",
-    "  oecd_country_names = list(df.country.unique())\n",
+    "    # get oecd country names\n",
+    "    # oecd_country_names = pd.read_csv('processed/fit.csv')\n",
+    "    oecd_country_names = list(df.country.unique())\n",
     "\n",
-    "  # match each oecd country name w/ wb country names\n",
-    "  # and store the oecd country name that do not match\n",
-    "  missing_countries = []\n",
-    "  for country in oecd_country_names:\n",
-    "    c = countries_table.loc[countries_table.wb_country_name== country,:]\n",
-    "    if len(c)==1:\n",
-    "      countries_table.loc[countries_table.wb_country_name== country,'oecd_country_name'] = country\n",
-    "    else:\n",
-    "      missing_countries.append(country)\n",
+    "    # match each oecd country name w/ wb country names\n",
+    "    # and store the oecd country name that do not match\n",
+    "    for country in oecd_country_names:\n",
+    "        c = countries_table.loc[countries_table.wb_country_name== country,:]\n",
+    "        if len(c)==1:\n",
+    "            countries_table.loc[countries_table.wb_country_name== country,'oecd_country_name'] = country\n",
+    "        else:\n",
+    "            missing_countries.append(country)\n",
     "elif len(missing_countries)>0:\n",
     "    print(f'WB and OECD country names do not match. Update table with missing {missing_countries}')\n",
     "else:\n",
-    "  countries_table = pd.read_csv(path_to_country_conversion_table)"
+    "    countries_table = pd.read_csv(path_to_country_conversion_table)"
    ]
   },
   {
@@ -291,7 +290,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.3 64-bit ('Anaconda3')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -305,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.7"
   },
   "vscode": {
    "interpreter": {

--- a/data/oecd/oecd_tariffs.ipynb
+++ b/data/oecd/oecd_tariffs.ipynb
@@ -124,6 +124,7 @@
     "# Load country mapping to ISO code\n",
     "metadata_dir = \"metadata\"\n",
     "path_to_country_conversion_table = os.path.join(metadata_dir, \"country_name_conversion.csv\")\n",
+    "missing_countries = []\n",
     "if not os.path.exists(path_to_country_conversion_table):\n",
     "  # get world bank country names and iso alpha3 code\n",
     "  countries_table = pd.read_csv('../worldbank/processed/ccdr.csv')\n",
@@ -143,10 +144,9 @@
     "      countries_table.loc[countries_table.wb_country_name== country,'oecd_country_name'] = country\n",
     "    else:\n",
     "      missing_countries.append(country)\n",
-    "elif len(missing_countries)>=0:\n",
+    "elif len(missing_countries)>0:\n",
     "    print(f'WB and OECD country names do not match. Update table with missing {missing_countries}')\n",
     "else:\n",
-    "  missing_countries = 0\n",
     "  countries_table = pd.read_csv(path_to_country_conversion_table)"
    ]
   },
@@ -291,7 +291,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.3 64-bit ('Anaconda3')",
    "language": "python",
    "name": "python3"
   },
@@ -305,7 +305,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.7"
+   "version": "3.8.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "67ce693c49850f0301d82a028bf465c408216de1661287538c64025448b796a6"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Bug fix on if statement.
Looks if `country_name_conversion.csv` already exists.
If not, creates a new conversion table to match OECD country names with WB country names. 
If we have names that do not match, manual update is required to check and validate a country name with the correspondent ISO alpha 3 country code. 