### PR TITLE
Add Global Energy Monitor's Coal Plant Change Database

### DIFF
--- a/data/globalenergymonitor/global_energy_monitor.py
+++ b/data/globalenergymonitor/global_energy_monitor.py
@@ -13,16 +13,15 @@ Wind: https://globalenergymonitor.org/projects/global-wind-power-tracker/
 Changes in Coal Tracker: https://drive.google.com/drive/folders/1kbLck8dEWlqUifv98AHNgL3KA_wMf1nL?usp=sharing
 
 """
-
+coal_changes = pd.read_excel("July 2022 GCPT Status Changes - 2014 - 2022.xlsx", sheet_name=None)
+coal_changes = coal_changes['Sheet1']
 solar_data = pd.read_excel("Global-Solar-Power-Tracker-May-2022.xlsx", sheet_name=None)
 solar_data = solar_data['Data']
 wind_data = pd.read_excel("Global-Wind-Power-Tracker-May-2022.xlsx", sheet_name=None)
 wind_data = wind_data['Data']
 gas_data = pd.read_excel("Global-Gas-Plant-Tracker-Aug-2022.xlsx", sheet_name=None)
 coal_data = pd.read_excel("Global-Coal-Plant-Tracker-July-2022.xlsx", sheet_name=None)
-coal_changes = pd.read_excel("July 2022 GCPT Status Changes - 2014 - 2022.xlsx", sheet_name=None)
-print(coal_changes)
-exit()
+
 """
 Things to extract and put in database:
 Context: 

--- a/data/globalenergymonitor/global_energy_monitor.py
+++ b/data/globalenergymonitor/global_energy_monitor.py
@@ -20,7 +20,9 @@ wind_data = pd.read_excel("Global-Wind-Power-Tracker-May-2022.xlsx", sheet_name=
 wind_data = wind_data['Data']
 gas_data = pd.read_excel("Global-Gas-Plant-Tracker-Aug-2022.xlsx", sheet_name=None)
 coal_data = pd.read_excel("Global-Coal-Plant-Tracker-July-2022.xlsx", sheet_name=None)
-
+coal_changes = pd.read_excel("July 2022 GCPT Status Changes - 2014 - 2022.xlsx", sheet_name=None)
+print(coal_changes)
+exit()
 """
 Things to extract and put in database:
 Context: 


### PR DESCRIPTION
This PR is adding in reading in and transforming the Global Energy Monitor's Coal Plant change database, so the changes to the coal plant tracker up to 2022. XXXX is the project did not exist, while otherwise the status is recorded. 