### PR TITLE
Added predictor experiments from paper

### DIFF
--- a/use_cases/eluc/.gitignore
+++ b/use_cases/eluc/.gitignore
@@ -3,6 +3,8 @@ predictors/*/*/**
 
 # Ignores saved predictors in experiments
 experiments/*/**
+# Ignores evaluation results in experiments
+experiments/*.csv
 
 data/*.zip
 *.nc

--- a/use_cases/eluc/.gitignore
+++ b/use_cases/eluc/.gitignore
@@ -2,9 +2,10 @@
 predictors/*/*/**
 
 # Ignores saved predictors in experiments
-experiments/*/**
-# Ignores evaluation results in experiments
-experiments/*.csv
+experiments/trained_predictors
+
+# Ignores predictor significance results
+experiments/predictor_significance
 
 data/*.zip
 *.nc

--- a/use_cases/eluc/.gitignore
+++ b/use_cases/eluc/.gitignore
@@ -1,4 +1,8 @@
-predictors/*/*/*
+# Ignores saved predictors
+predictors/*/*/**
+
+# Ignores saved predictors in experiments
+experiments/*/**
 
 data/*.zip
 *.nc

--- a/use_cases/eluc/.gitignore
+++ b/use_cases/eluc/.gitignore
@@ -1,8 +1,5 @@
 # Ignores saved predictors
-predictors/*/*/**
-
-# Ignores saved predictors in experiments
-experiments/trained_predictors
+predictors/*/trained_models/
 
 # Ignores predictor significance results
 experiments/predictor_significance

--- a/use_cases/eluc/experiments/predictor_experiments.ipynb
+++ b/use_cases/eluc/experiments/predictor_experiments.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "results = nnp.fit(dataset.train_df[nn_config[\"features\"]], dataset.train_df[nn_config[\"label\"]], verbose=True)\n",
-    "nnp.save(\"experiments/neural_network\")"
+    "nnp.save(\"experiments/trained_predictors/neural_network\")"
    ]
   },
   {
@@ -109,7 +109,7 @@
     }
    ],
    "source": [
-    "nnp.load(\"experiments/neural_network\")\n",
+    "nnp.load(\"experiments/trained_predictors/neural_network\")\n",
     "print(f\"MAE Neural Net: {mean_absolute_error(dataset.test_df[nn_config['label']], nnp.predict(dataset.test_df[nn_config['features']]))}\")"
    ]
   },
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "linreg.fit(dataset.train_df[constants.DIFF_LAND_USE_COLS], dataset.train_df[\"ELUC\"])\n",
-    "linreg.save(\"experiments/linear_regression\")"
+    "linreg.save(\"experiments/trained_predictors/linear_regression\")"
    ]
   },
   {
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "linreg.load(\"experiments/linear_regression\")\n",
+    "linreg.load(\"experiments/trained_predictors/linear_regression\")\n",
     "print(f\"MAE Linear Regression: {mean_absolute_error(dataset.test_df['ELUC'], linreg.predict(dataset.test_df[constants.DIFF_LAND_USE_COLS]))}\")"
    ]
   },
@@ -191,7 +191,7 @@
     "# Note: The original paper trains from 1982 onwards but this is too slow and large for the\n",
     "# purpose of this example.\n",
     "forest.fit(dataset.train_df.loc[2002:][constants.NN_FEATS], dataset.train_df.loc[2002:][\"ELUC\"])\n",
-    "forest.save(\"experiments/random_forest\")"
+    "forest.save(\"experiments/trained_predictors/random_forest\")"
    ]
   },
   {
@@ -208,7 +208,7 @@
     }
    ],
    "source": [
-    "forest.load(\"experiments/random_forest\")\n",
+    "forest.load(\"experiments/trained_predictors/random_forest\")\n",
     "print(f\"MAE Random Forest: {mean_absolute_error(dataset.test_df['ELUC'], forest.predict(dataset.test_df[constants.NN_FEATS]))}\")"
    ]
   },
@@ -360,6 +360,8 @@
     "    :param override_start_year: If not None, overrides the start year of the test data on the ALL region.\n",
     "        (This is currently only used for the random forest)\n",
     "    \"\"\"\n",
+    "    save_dir = Path(save_path).parent\n",
+    "    save_dir.mkdir(parents=True, exist_ok=True)\n",
     "    if not Path(save_path).exists():\n",
     "        with open(save_path, \"w\") as f:\n",
     "            f.write(\"region,eval,mae,time\\n\")\n",
@@ -415,7 +417,7 @@
     "    override_start_year = None\n",
     "    if model_name == \"random_forest\":\n",
     "        override_start_year = 2002\n",
-    "    train_and_test(30, model_constructor, config, dataset.train_df, dataset.test_df, f\"experiments/{model_name}_eval.csv\", override_start_year=override_start_year)"
+    "    train_and_test(30, model_constructor, config, dataset.train_df, dataset.test_df, f\"experiments/predictor_significance/{model_name}_eval.csv\", override_start_year=override_start_year)"
    ]
   },
   {
@@ -431,9 +433,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linreg_results = pd.read_csv(\"experiments/linear_regression_eval.csv\")\n",
-    "nn_results = pd.read_csv(\"experiments/neural_network_eval.csv\")\n",
-    "forest_results = pd.read_csv(\"experiments/random_forest_eval.csv\")"
+    "linreg_results = pd.read_csv(\"experiments/predictor/significance/linear_regression_eval.csv\")\n",
+    "nn_results = pd.read_csv(\"experiments/predictor/significance/neural_network_eval.csv\")\n",
+    "forest_results = pd.read_csv(\"experiments/predictor_significance/random_forest_eval.csv\")"
    ]
   },
   {

--- a/use_cases/eluc/experiments/predictor_experiments.ipynb
+++ b/use_cases/eluc/experiments/predictor_experiments.ipynb
@@ -1,0 +1,435 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Predictor Experiments\n",
+    "#### This notebook is to replicate the process used in [Discovering Effective Policies for Land-Use Planning](https://doi.org/10.48550/arXiv.2311.12304)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from tqdm import tqdm\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from sklearn.metrics import mean_absolute_error\n",
+    "\n",
+    "from data.eluc_data import ELUCData\n",
+    "from data import constants\n",
+    "from predictors.predictor import Predictor\n",
+    "from predictors.neural_network.neural_net_predictor import NeuralNetPredictor\n",
+    "from predictors.sklearn.sklearn_predictor import LinearRegressionPredictor, RandomForestPredictor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = ELUCData()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train Models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Neural Network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nn_config = {\n",
+    "    \"features\": constants.NN_FEATS,\n",
+    "    \"label\": \"ELUC\",\n",
+    "    \"hidden_sizes\": [4096],\n",
+    "    \"linear_skip\": True,\n",
+    "    \"dropout\": 0,\n",
+    "    \"device\": \"mps\",\n",
+    "    \"epochs\": 3,\n",
+    "    \"batch_size\": 2048,\n",
+    "    \"train_pct\": 1,\n",
+    "    \"step_lr_params\": {\"step_size\": 1, \"gamma\": 0.1},\n",
+    "}\n",
+    "nnp = NeuralNetPredictor(**nn_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = nnp.fit(dataset.train_df[nn_config[\"features\"]], dataset.train_df[nn_config[\"label\"]], verbose=True)\n",
+    "nnp.save(\"experiments/neural_network\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAE Neural Net: 0.04711493104696274\n"
+     ]
+    }
+   ],
+   "source": [
+    "nnp.load(\"experiments/neural_network\")\n",
+    "print(f\"MAE Neural Net: {mean_absolute_error(dataset.test_df[nn_config['label']], nnp.predict(dataset.test_df[nn_config['features']]))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Linear Regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linreg_config = {\n",
+    "    \"features\": constants.DIFF_LAND_USE_COLS,\n",
+    "    \"n_jobs\": -1,\n",
+    "}\n",
+    "linreg = LinearRegressionPredictor(**linreg_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linreg.fit(dataset.train_df[constants.DIFF_LAND_USE_COLS], dataset.train_df[\"ELUC\"])\n",
+    "linreg.save(\"experiments/linear_regression\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAE Linear Regression: 0.07567060738801956\n"
+     ]
+    }
+   ],
+   "source": [
+    "linreg.load(\"experiments/linear_regression\")\n",
+    "print(f\"MAE Linear Regression: {mean_absolute_error(dataset.test_df['ELUC'], linreg.predict(dataset.test_df[constants.DIFF_LAND_USE_COLS]))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Random Forest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forest_config = {\n",
+    "    \"n_jobs\": -1,\n",
+    "    \"max_features\": \"sqrt\",\n",
+    "    \"random_state\": 42\n",
+    "}\n",
+    "forest = RandomForestPredictor(features=constants.NN_FEATS, **forest_config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: The original paper trains from 1982 onwards but this is too slow and large for the\n",
+    "# purpose of this example.\n",
+    "forest.fit(dataset.train_df.loc[2002:][constants.NN_FEATS], dataset.train_df.loc[2002:][\"ELUC\"])\n",
+    "forest.save(\"experiments/random_forest\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAE Random Forest: 0.037707034150731636\n"
+     ]
+    }
+   ],
+   "source": [
+    "forest.load(\"experiments/random_forest\")\n",
+    "print(f\"MAE Random Forest: {mean_absolute_error(dataset.test_df['ELUC'], forest.predict(dataset.test_df[constants.NN_FEATS]))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Heatmaps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_heatmap(model: Predictor, sample: pd.DataFrame, features=None, scale={}, title=None, save_path=None):\n",
+    "    \"\"\"\n",
+    "    Creates a 2d heatmap of the outcomes of the model on synthetic data.\n",
+    "    The columns correspond to current land type and the rows are the land type converted to.\n",
+    "    Synthetic data is created by using the non-land features of the sample and taking the cross\n",
+    "    join between the artificial land use change from 0 to 1 of every type.\n",
+    "    \"\"\"\n",
+    "    dummy_data = []\n",
+    "    for i in range(len(constants.LAND_USE_COLS)):\n",
+    "        for j in range(len(constants.LAND_USE_COLS)):\n",
+    "            row = [0 for _ in range(len(constants.LAND_USE_COLS) * 2)]\n",
+    "            row[i] = 1.0\n",
+    "            if i == j:\n",
+    "                row[len(constants.LAND_USE_COLS) + j] = 0.0\n",
+    "            else:\n",
+    "                row[len(constants.LAND_USE_COLS) + j] = 1.0\n",
+    "                row[len(constants.LAND_USE_COLS) + i] = -1.0\n",
+    "            dummy_data.append(dict(zip(constants.LAND_USE_COLS + constants.DIFF_LAND_USE_COLS, row)))\n",
+    "\n",
+    "    dummy_df = pd.DataFrame(dummy_data)\n",
+    "\n",
+    "    # Gets sample of lat/lon/time/cell_area\n",
+    "    non_land_df = sample[constants.NONLAND_FEATURES]\n",
+    "    nn_input_df = dummy_df.merge(non_land_df, how=\"cross\")\n",
+    "    if features:\n",
+    "        nn_input_df = nn_input_df[features]\n",
+    "    preds = model.predict(nn_input_df)\n",
+    "    # Aggregate samples. Since pandas merge maintains left key order, we can just sum each group of len(samples)\n",
+    "    # Thanks, ChatGPT!\n",
+    "    chunks = np.split(preds, len(preds) // len(sample))\n",
+    "    sums = np.sum(chunks, axis=1)\n",
+    "    preds = sums / len(sample)\n",
+    "\n",
+    "    # Rearrange the heatmap data into 2D shape\n",
+    "    heatmap_data = np.zeros((len(constants.LAND_USE_COLS), len(constants.LAND_USE_COLS)))\n",
+    "    for i in range(len(preds)):\n",
+    "        heatmap_data[i // len(constants.LAND_USE_COLS), i % len(constants.LAND_USE_COLS)] = preds[i]\n",
+    "    \n",
+    "    # Hide the ability to move land to primf/primn\n",
+    "    idxs = [constants.LAND_USE_COLS.index(col) for col in constants.RECO_COLS]\n",
+    "    non_idxs = [constants.LAND_USE_COLS.index(col) for col in constants.LAND_USE_COLS if (col not in constants.RECO_COLS)]\n",
+    "    heatmap_data = heatmap_data[idxs + non_idxs,:]\n",
+    "    heatmap_data = heatmap_data[:, idxs]\n",
+    "\n",
+    "    # Draw heatmap\n",
+    "    colors = [\"darkgreen\", \"white\", \"red\"]\n",
+    "    bins = 1000\n",
+    "    cmap = LinearSegmentedColormap.from_list(\"custom_cmap\", colors, N=bins)\n",
+    "    sorted_labels = np.array(constants.LAND_USE_COLS)[idxs + non_idxs]\n",
+    "    ax = sns.heatmap(heatmap_data, center=0, cmap=cmap, xticklabels=constants.RECO_COLS, yticklabels=sorted_labels, **scale)\n",
+    "    ax.invert_yaxis()\n",
+    "    plt.xlabel(\"To\")\n",
+    "    plt.ylabel(\"From\")\n",
+    "    if title:\n",
+    "        plt.title(title)\n",
+    "    if save_path:\n",
+    "        plt.savefig(save_path, format=\"png\", dpi=300)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhSklEQVR4nO3deZgdVbnv8e8vCQQCQojMkwGNyGiIDDIHmZ0ATQgCQQ54Igp4PEeuyNVHIMhFRBQ5ytBgbqKJjBoF5BAJmCAoQwgBEsYIgYRRIGAAA6T7PX/Uatg03dW7u2uP/fvw7KerVq2qeld36LdXrapVigjMzMy6MqDWAZiZWX1zojAzs1xOFGZmlsuJwszMcjlRmJlZLicKMzPL5URhVkLS6ZKm1joOs3riRGE1JWmRpBckrVZS9hVJs2oYVqckjZYUki7sUH6bpGPKPEZI+khFAjSrECcKqwcDgf+o9EkkDSrgMK8D4yUNL+BYZg3BicLqwbnAyZKGdrZR0sck3STpZUmPSDqsZNssSV8pWT9G0m0l6yHpBEmPAY+lsp9JWizpn5LukbRHD2J9BZgMnNZVBUnHSnpI0lJJMyR9KJXfmqrcJ+k1SeN6cF6zmnGisHowB5gFnNxxQ7okdRPwG2Bd4HDgQklb9eD4hwA7A+373A2MBIal414taZUeHO8s4IuStugk3oOB/wt8AVgH+AtwOUBE7JmqfTwiVo+IK3twTrOacaKwevF94CRJ63Qo/yywKCL+f0SsiIh7gd8CY3tw7LMj4uWI+BdAREyNiJfS8c4DBgPv+6XflYh4DrgYmNjJ5uPT+R6KiBXA/wNGtvcqzBqRE4XVhYiYD1wPfKfDpg8BO0t6pf0DHAms34PDLy5dkXRyujT0ajremsDaPQz5HOAASR/vJN6flcT6MiBgox4e36xuFDG4Z1aU04C5wHklZYuB2RGxXxf7vA4MKVnvLIG8M0VyGo/4NrAPsCAi2iQtJftlXraIeEnS+cCZHTYtBs6KiGk9OZ5ZPXOPwupGRCwErgS+UVJ8PfBRSeMlrZQ+O0raMm2fB3xB0pB02+lx3ZzmA8AK4B/AIEnfB9boZcg/AXYFtiwpuxg4VdLWAJLWlFR6mex5YPNens+sJpworN5MBN55piIilgH7kw1iPwM8R3bZZ3Cq8lPgLbJfwFOA7v6SnwHcCDwKPAksp8OlqXJFxD+BH5ENireXTU/xXSHpn8B84KCS3U4HpqRLU4dh1gDkFxeZmVke9yjMzCyXE4WZmeVyojAzs1xOFGZmdUzSpDRx5vySstMlPS1pXvp8umTbqZIWpuluDigkhv4ymN0WbU3X0Gl3NOet+hut1ZzPpl1333W1DqFw+2+9f61DqIiDtjmoR8/VvI9U/u+biNxzSdoTeA34VURsk8pOB16LiB93qLsV2ZQxOwEbAjOBj0ZEa0/C78g9CjOzog0YUP6nGxFxK9kT/uU4GLgiIt6MiCeAhWRJo0+cKMzMitaDRCFpgqQ5JZ8JZZ7lREn3p0tTa6WyjXjvc0FLKGD6GCcKM7OiSWV/IqIlInYo+bSUcYaLgA+TzYL8LO+d9qZwnuvJzKxoZVxS6ouIeL59WdKlZFPdADwNbFJSdeNU1ifuUZiZFW3QoPI/vSBpg5LVQ8mmigG4Fjhc0mBJmwEjgLv61BbcozAzK16BPQpJlwOjgbUlLSGbZXm0pJFkMyMvAr4KEBELJF0FPEg2+eUJfb3jCZwozMyKV2CiiIgvdVL8y5z6Z5G9hbEwThRmZkVT3x7DqDdOFGZmRavwYHa11bw1kiZLGlPrOMzMClPgA3f1oKY9Cknu0ZhZ8+nl3Uz1qmLpTNLwDpNYnZwmspol6XxJc4D/SJv3TU8kPirpsyX7/0XS3PTZNZWPTse4RtLDkqZJTXZB0Mwam3sUhVg5InaA7NITMJxsPpIPA39O7z5+AdgvIpZLGkE20dUOaf/tga3JXo15O7AbcFs1G2Bm1qUGSQDlqlVrruywflVEtEXEY8DjwMeAlYBLJT0AXA1sVVL/rohYEhFtwDyyRPM+pXOotLSU81S8mVkB3KMo2wrem4hWKVl+vUPdjlPyBvCfwPPAx9Nxlpdsf7NkuZUu2pHmTGmB5pxm3MzqVJNdDa9kOnseWFfSByUNBj6bU3espAGSPgxsDjwCrAk8m3oN44GBFYzVzKw4FZ7Co9oqFmVEvC1pItk8I08DD+dUfyrVWwM4Po1LXAj8VtLRwI28vxdiZlafGuSSUrkqms4i4gLggm7qHNNF+WPAdiVFp6TyWcCsknon9jFMM7NiOVGYmVmuJhujcKIwMyuaexRmZpbLicLMzHI1yN1M5Wqu1piZ1QP3KMzMLJcThZmZ5XKiMDOzXL491szMcrlH0ZgGrDWs1iEUbvzvflfrECoidtm71iFUxDOvPFPrEAp30Nrb1zqE+uS7nszMLJd7FGZmlsuJwszMcnkw28zMcrlHYWZmuTyYbWZmudyjMDOzXE4UZmaWq8kSRc1bI2mipH1rHYeZWWEGDCj/0w1JkyS9IGl+SdkwSTdJeix9XSuVS9IFkhZKul/SqEKaU8RBekvSwIj4fkTMrGUcZmaFksr/dG8ycGCHsu8AN0fECODmtA5wEDAifSYAFxXRnIolCknDJT0saZqkhyRdI2mIpEWSzpE0FxgrabKkMWmfRZLOljRP0hxJoyTNkPR3ScenOqMlzUrHaz9+c920bGaNbdCg8j/diIhbgZc7FB8MTEnLU4BDSsp/FZk7gKGSNuhrcyrdo9gCuDAitgT+CXw9lb8UEaMi4opO9nkqIkYCfyHLpGOATwJnlNTZHvgmsBWwObBbJYI3M+uVHlx6kjQh/WHc/plQxhnWi4hn0/JzwHppeSNgcUm9JamsTyo9mL04Im5Py1OBb6TlK3P2uTZ9fQBYPSKWAcskvSlpaNp2V0QsAZA0DxgO3NbxQOkbPgHgklVXZcLKK/e+JWZm5erBYHZEtAAtvT1VRISk6O3+5ah0ougYfPv66zn7vJm+tpUst68P6lAHoJUu2vGeH8DQoRX9RpqZvaPyV8Ofl7RBRDybLi29kMqfBjYpqbdxKuuTSl962lTSLmn5CDr5q9/MrOkUeNdTF64FvpyWvwz8oaT86HT30yeBV0suUfVapRPFI8AJkh4C1qKgEXgzs7pW7O2xlwN/A7aQtETSccAPgf0kPQbsm9YBbgAeBxYCl/LuuHCfVPrS04qIOKpD2fDSlYg4pmR5eMnyZLLB7I7bZqVPe/mJRQRqZlaYAud6iogvdbFpn07qBnBCYSdP/GS2mVnRmuzJ7IoliohYBGxTqeObmdUtJwozM8vlRGFmZrmabLIIJwozs6L5xUVmZpbLl57MzCyXE4WZmeVyojAzs1wezG5Qb7xR6wiKt8/7HsxsCjrppFqHUBFHHXlkrUMo3rRptY6gMr71rb7t7x6FmZnl8l1PZmaWyz0KMzPL5URhZma5nCjMzCyXE4WZmeXy7bFmZpbLdz2ZmVmuJrv0VFetkTRR0r493OdcSQsknVupuMzMeqTAd2bXg7rpUUgaGBHf78WuE4BhEdFadExmZr3SZGMUVUlnkoZLeljSNEkPSbpG0hBJiySdI2kuMFbSZElj0j6LJJ0taZ6kOZJGSZoh6e+Sjk91rgVWB+6RNK4abTEz65Z7FL22BXBcRNwuaRLw9VT+UkSMApB0YId9noqIkZJ+CkwGdgNWAeYDF0fE5yW9FhEjq9ICM7NyNNlgdjXT2eKIuD0tTwV2T8tX5uxzbfr6AHBnRCyLiH8Ab0oa2t0JJU1IvZE5LW1tvY3bzKxn3KPotehi/fWcfd5MX9tKltvXu409IlqAFgBWXrnj+c3MKqNBEkC5qtmaTSXtkpaPAG6r4rnNzKqnyXoU1YzyEeAESQ8BawEXVfHcZmbV02SJopqXnlZExFEdyoaXrkTEMSXLw0uWJ5MNZne2bfUigzQz67MGSQDlaq6heTOzejBwYK0jKFRVEkVELAK2qca5zMxqzj0KMzPL5URhZma5Ck4UkhYBy4BWsvHeHSQNI3sObTiwCDgsIpYWeuKkudKemVk9kMr/lG/viBgZETuk9e8AN0fECODmtF4RThRmZkWrzu2xBwNT0vIU4JC+ht0VJwozs6INGlT2p3SqofSZ0MkRA/iTpHtKtq8XEc+m5eeA9SrWnEod2Mys3+pBT+E9Uw11bfeIeFrSusBNkh7ucIyQVLFpipwozMyKVvBgdkQ8nb6+IGk6sBPwvKQNIuJZSRsALxR60hL9J1GcfXatIyhcfOu/ah1CRVTu76LamvXo7FqHULi9mvXfYF8PUGCikLQaMCAilqXl/YGJZLNrfxn4Yfr6h8JO2kH/SRRmZtVSbI9iPWC6sjukBgG/iYgbJd0NXCXpOOBJ4LAiT1rKicLMrGgFTuEREY8DH++k/CVgn8JOlMOJwsysaH4y28zMcjlRmJlZLicKMzPL5URhZma5ejaHU91zojAzK9qg5vrV2jD9I0mTJY2pdRxmZt3yO7PNzCxXgySAclUsUaRHza8CNgYGAmcCC4GfAKsDLwLHpHlKPgJcDKxD9mKOscDjwH8D+wGLgbdKjr2IbFrdzwErAWMj4j2TZJmZ1YwTRdkOBJ6JiM8ASFoT+B/g4Ij4h6RxwFnAscA04IcRMV3SKmSXxA4FtgC2InuE/UFgUsnxX4yIUZK+DpwMfKWCbTEzK1+TJYpKtuYBYD9J50jaA9gE2IZsitx5wPeAjSV9ANgoIqYDRMTyiHgD2BO4PCJaI+IZ4JYOx/9d+noP2asA36d0nveWO+4ouHlmZl0YOLD8TwOoWI8iIh6VNAr4NPADsl/0CyJil9J6KVH0xpvpaytdtOM987yfd16TzklqZnXHPYrySNoQeCMipgLnAjsD60jaJW1fSdLWEbEMWCLpkFQ+WNIQ4FZgnKSBaa71vSsVq5lZoXzXU9m2Bc6V1Aa8DXwNWAFckMYrBgHnAwuA8cAlkiamumOB6cCnyMYmngL+VsFYzcyK0yAJoFyVvPQ0A5jRyaY9O6n7GFlS6OjELo49vGR5DjC6V0GamVVCf0wUkjYDTiIbNH5nn4j4fGXCMjNrYP10Co/fA78ErgPaKhaNmVkzWGmlWkdQqHITxfKIuKCikZiZNYt+2qP4maTTgD/x7m2pRMTcikRlZtbI+uMYBdkdTOPJBpzbLz0FnQ9Am5n1b/00UYwFNo+It7qtaWbW3/XTRDEfGAq8ULlQzMyaRD9NFEOBhyXdzXvHKHx7rJlZRw0yh1O5yk0Up1U0CjOzZtIfexQRMVvSesCOqeiuiGisy1CXXVbrCAqnD36w1iFUxogRtY6gIvbaba9ah1A43f9ArUOojO2269v+TZYoymqNpMOAu8gGtQ8D7vRrSc3MutBPJwX8LrBjey9C0jrATOCaSgVmZtawGiQBlKvcRDGgw6Wml6jsS4/MzBrXoEpOzF195bbmRkkzgMvT+jjghsqEZGbW4PrbFB6SBFxANpC9eypuaX91qZmZddDfLj1FREi6ISK25d33VJuZWVcKThSSDgR+BgwELouIHxZ6gm6U25q5knbsvpqZmRV515OkgcAvgIOArYAvSdqqwi14j3LHKHYGjpK0CHgdEFlno483G5uZNaFiexQ7AQsj4nEASVcAB5O9JroqchOFpE0j4inggCrFY2bW8NqIsusO1IAJwISSopaIaClZ3whYXLK+hOyP96rprkfxe2BURDwp6bcR8cUqxNQtSZOB6yPiGkl7ABcDbwO7RMS/ahqcmfV7bW3lvwg0JYWWbivWUHeJovQer80rGUgfHAmcHRFTax2ImRlAWxT6xuingU1K1jdOZVXT3YW06GK5RyStJumPku6TNF/SOEmfkDRb0j2SZkjaINX9iKSZqe5cSR9W5ueSHpE0E1g31f0K2ZQiZ0qa1tv4zMyK1BZtZX/KcDcwQtJmklYGDgeurWgDOuiuR/FxSf8k61msmpbh3cHsNco8z4HAMxHxGQBJawL/AxwcEf+QNA44CzgWmAb8MCKmS1qFLJkdCmxBNuK/HtkgzqSIuEzS7qTLUGXGYmZWUUX2KCJihaQTgRlkt8dOiogFhZ2gDLmJIiKKmlT9AeA8SecA1wNLgW2Am7Ln+RgIPCvpA8BG7Q/zRcRyAEl7ApdHRCvwjKRbyjmppHcGiS5Zf30mDB1aUHPMzLoW0esLMF0d7wZqOBtGVSYkiYhHJY0CPg38ALgFWBARu5TWS4miyPO+O0i05ZbF/uTMzLrwdtvbtQ6hUFV5zlzShsAbacD5XLJbu9aRtEvavpKkrSNiGbBE0iGpfLCkIcCtwDhJA9NYxt7ViNvMrDciouxPI6jWFIfbAudKaiO7jfVrwArggjReMQg4H1gAjAcukTQx1R0LTAc+RTY28RTwtyrFbWbWYz25PbYRVOvS0wyygZiO9uyk7mNkSaGjE7s49jF9Cs7MrGAF3x5bc801abqZWR1wojAzs1ytba21DqFQThRmZgVzj8LMzHI5UZiZWS4nCjMzy+XbY83MLJd7FGZmlmtF24pah1Co/pMojjii1hEU7/Ofr3UEFRHD1qp1CBUx98m5tQ6hcNtvu32tQ6iIvs5t5B6FmZnlapQ5nMrlRGFmVjD3KMzMLJcThZmZ5fLtsWZmlstzPZmZWS5fejIzs1xOFGZmlsuJwszMcjlRmJlZrhWtnsKjVyQJUESTpVozsw6arUfR1ylNckkaLukRSb8C5gO/lDRH0gJJZ5TUWyTpDElzJT0g6WOpfB1JN6X6l0l6UtLaadtRku6SNE/SJZIGVrItZmblioiyP42gookiGQFcGBFbA9+KiB2A7YC9JG1XUu/FiBgFXAScnMpOA25J+14DbAogaUtgHLBbRIwEWoEjq9AWM7NutUVb2Z9GUI1E8WRE3JGWD5M0F7gX2BrYqqTe79LXe4DhaXl34AqAiLgRWJrK9wE+AdwtaV5a37zjiSVNSD2YOS1z5hTWIDOzPM2WKKoxRvE6gKTNyHoKO0bEUkmTgVVK6r2ZvraWEZeAKRFxal6liGgBWgA488zG6OOZWcNrlARQrmr0KNqtQZY0XpW0HnBQGfvcDhwGIGl/oP1FBTcDYyStm7YNk/Sh4kM2M+u5Fa0ryv40gqolioi4j+yS08PAb8iSQHfOAPaXNB8YCzwHLIuIB4HvAX+SdD9wE7BBRQI3M+uhag1mSzpd0tPppp55kj5dsu1USQvTDUUH9OU8Fb30FBGLgG1K1o/pot7wkuU5wOi0+ipwQESskLQL2WWrN1O9K4ErKxG3mVlfVPnS008j4selBZK2Ag4nGwveEJgp6aMR0avZCuv9gbtNgaskDQDeAv69xvGYmXWrDsYoDgauSH9YPyFpIbAT8LfeHKyuE0VEPAY050t5zaxp9SRRSJoATCgpakk34pTrRElHA3PIHkFYCmwE3FFSZ0kq65W6ThRmZo1oRVv5g9TvuTuzE5JmAut3sum7ZM+dnQlE+noecGxPYi2HE4WZWcGKvPQUEfuWU0/SpcD1afVpYJOSzRunsl6p5u2xZmb9QltbW9mfvpBUerfnoWRTJQFcCxwuaXB6hm0EcFdvz+MehZlZwao4h9OPJI0ku/S0CPhqOv8CSVcBDwIrgBN6e8cTOFGYmRWuWnc9RcT4nG1nAWcVcR4nCjOzgtXB7bGF6j+JYvDgWkdQuBi2VveVGtDdT9xd6xAq4qo5V9U6hMLNfGhmrUOoiFMOPKVP+/fkrqdG0H8ShZlZlTTKeybK5URhZlYwX3oyM7Ncfb3ttd44UZiZFcw9CjMzy+VEYWZmuXzXk5mZ5XKPwszMcvn2WDMzy+UeRQ1JGg28FRF/rXEoZmZd8u2xtTUaeA14X6KQNCgimmsEycwakgeze0nScOBG4B5gFLAAOBo4GfgcsCpZAvhqRISkbwDHk02R+yDwnbTeKuko4CTgOGA52etSbwf+q1rtMTPrii899c0WwHERcbukScDXgZ9HxEQASb8GPgtcR5YYNouINyUNjYhXJF0MvBYRP071jyN7c9OufZlr3cysSM02mF3tN9wtjojb0/JUYHdgb0l3SnoA+BSwddp+PzAt9R7y+nFXd5UkJE2QNEfSnJY77yyoCWZm+dqirexPI6h2ouiYZgO4EBgTEdsClwKrpG2fAX5Bdpnqbkld9X5e7/JkES0RsUNE7DBh5537FrmZWZmcKPpmU0m7pOUjgNvS8ouSVgfGAEgaAGwSEX8GTgHWBFYHlgEfqG7IZmY902yJotpjFI8AJ6TxiQeBi4C1yF4I/hzQ/saagcBUSWsCAi5IYxTXAddIOphsMNvMrO6saPVdT32xIiKO6lD2vfTpaPeOBRHxKLBdSdFfCozNzKwQjdJTKFejPUdhZlb3nCh6KSIWAdtU63xmZrXSbLfHukdhZlYw9yjMzCyX53oyM7NcnuvJzMxyeYzCzMxyeYzCzMxyOVGYmVkuJ4oGFd/+P7UOoXDT506vdQgVMeWvU2odQkU89NxDtQ6hcKutvFqtQ6iIUw48pU/7N9sUHtWeFNDMrOm19eC/vpA0VtICSW2Sduiw7VRJCyU9IumAkvIDU9lCSd8p5zz9pkdhZlYtVXyOYj7wBeCS0kJJWwGHk73fZ0NgpqSPps2/APYDlpC9wuHaiHgw7yROFGZmBavW7bER8RCApI6bDgauiIg3gSckLQR2StsWRsTjab8rUt3cROFLT2ZmBevJ+yhK38SZPhMKCGEjYHHJ+pJU1lV5LvcozMwK1pO7niKiBWjparukmcD6nWz6bkT8oefR9ZwThZlZwYqcwiMi9u3Fbk8Dm5Ssb5zKyCnvki89mZkVrK2trexPhVwLHC5psKTNgBHAXWRvER0haTNJK5MNeF/b3cHcozAzK1hQncFsSYcC/w2sA/xR0ryIOCAiFki6imyQegVwQkS0pn1OBGaQvXJ6UkQs6O48ThRmZgWr1u2xETEd6PTJ24g4Czirk/IbgBt6cp66TRSSBkVEcz3eaGb9Qmv2x3vTqGmikHQ0cDIQwP1AK7Ac2B64XdKvgIuBIcDfgWMjYqmkWcB9wF5kbTg2Iu6qfgvMzN7P04wXRNLWwPeAXSPiRUnDgJ+QjcLvGhGtku4HToqI2ZImAqcB30yHGBIRIyXtCUzC7+M2szrRbC8uquVdT58Cro6IFwEi4uVUfnVKEmsCQyNidiqfAuxZsv/lab9bgTUkDe14gtIHWVpaurxN2cysUD154K4R1OMYxetl1uvYt3tfX6/0QZagyfqCZla3mu2d2bXsUdwCjJX0QYB06ekdEfEqsFTSHqloPDC7pMq4tN/uwKupvplZzUUP/msENetRpPt8zwJmS2oF7u2k2peBiyUNAR4H/q1k23JJ9wIrAcdWPGAzszI1W4+ippeeImIK2dhDV9vnAZ/sYvPUiPhmBcIyM+uTZhvMrscxCjOzhtYog9TlashEERGjax2DmVlX/ByFmZnlco/CzMxytbZ5Cg8zM8vRKLe9lsuJwsysYCtafdeTmZnl8BiFmZnlcqIwM7NczZYo1Gz3+9YDSRPShIRNoxnbBM3ZrmZsEzRvuxpBLScFbGYTah1ABTRjm6A529WMbYLmbVfdc6IwM7NcThRmZpbLiaIymvE6ajO2CZqzXc3YJmjedtU9D2abmVku9yjMzCyXE4WZmeVyorBekzRa0q61jsPKJ2mypDFpeQ9JCyTNk7RqrWPrrdI2WWU4URREUn98yn000GmiqOX3Qxn/2+7ekcDZETEyIv5V62Csfvl/ph6QdLSk+yXdJ+nX6S+ZiyXdCfxI0khJd6Q60yWtlfabJeln6S+3+ZJ2qnFTkDRc0sOSpkl6SNI1koZI+r6ku1OcLZKU6n9D0oOpbVdIGg4cD/xnatceHb8fNWjPI5J+BcwHfilpTvqL+YySeosknSFprqQHJH0sla8j6aZU/zJJT0paO207StJdqZ2XSBpYxXatJumP6d/cfEnjJH1C0mxJ90iaIWmDVPcjkmamunMlfTglzZ+n781MYN1U9yvAYcCZkqZVqz2VbFOq3+nP1/ooIvwp4wNsDTwKrJ3WhwGTgeuBgansfmCvtDwROD8tzwIuTct7AvProD3DgQB2S+uTgJOBYSV1fg18Li0/AwxOy0PT19OBk0vqv+f7UYP2tAGfbP/5pK8D0/d/u7S+CDgpLX8duCwt/xw4NS0fmL43awNbAtcBK6VtFwJHV7FdX2z/t5PW1wT+CqyT1scBk9LyncChaXkVYAjwBeCm9H3YEHgFGFPy8xpTg59VJdvU6c/Xn759+uPlkt76FHB1RLwIEBEvpz+2r46IVklrkv0CnZ3qTwGuLtn/8rTfrZLWkDQ0Il6pXvidWhwRt6flqcA3gCckfZvsf8hhwAKyX5T3A9Mk/R74fc4xr46IWr3e68mIuCMtHyZpAtnElxsAW5G1AeB36es9ZL90AHYHDgWIiBslLU3l+wCfAO5OP+9VgRcq2YgOHgDOk3QOWRJeCmwD3JTiGQg8K+kDwEYRMT21YTmApD2By9PP5BlJt1Qx9q5Uuk2d/XytD5wo+u71Mut1fGClHh5g6SymC4EdImKxpNPJ/ooD+AxZb+hzwHclbdvFMcv9flTC6wCSNiPrHe0YEUslTebddgC8mb620v3/AwKmRMSpBcdaloh4VNIo4NPAD4BbgAURsUtpvfRLtSFUoU09+flaGTxGUb5bgLGSPgggaVjpxoh4FVgqaY9UNB6YXVJlXNpvd+DVVL/WNpXU/j/nEcBtaflFSasD7XfHDAA2iYg/A6eQXSpYHVgG1OMvqDXIksarktYDDipjn9vJrtkjaX9grVR+MzBGUvu1/WGSPlR8yJ2TtCHwRkRMBc4FdgbWaf+5SVpJ0tYRsQxYIumQVD5Y0hDgVmCcpIHpuv/e1Yq9K83YpmbnbFumiFgg6SxgtqRW4N5Oqn0ZuDj9Y34c+LeSbcsl3QusBBxb8YDL8whwgqRJwIPARWS/IOcDzwF3p3oDganp8pqACyLiFUnXAddIOhg4qerRdyEi7kvf64eBxWRJoDtnAJdLGg/8jaz9yyLiRUnfA/6UEubbwAnAk5WJ/n22Bc6V1JbO/TVgBXBB+nkMAs4nu0Q4HrhE0sRUdywwneyy6YPAU6lttdaMbWpqnsKjCiTNIhv0nVPrWNopu2vp+ojYptax1ANJg4HWiFiR/rK9KCJG1jgss7rgHoVZZlPgqtRreAv49xrHY1Y33KMwM7NcHsw2M7NcThRmZpbLicLMzHJ5MNv6jfQMzM1pdX2yB7L+kdZ3ioi3ahKYWZ3zYLb1S+mp89ci4se1jsWs3vnSk/VrkvaRdG+aaXRSep7CzEo4UVh/tgrZDKrjImJbskuxX6tpRGZ1yInC+rOBwBMR8Whan0I28aGZlXCiMDOzXE4U1p+1AsMlfSStd5zx18xworD+bTnZDL9XS3qA7A15F9c2JLP649tjzcwsl3sUZmaWy4nCzMxyOVGYmVkuJwozM8vlRGFmZrmcKMzMLJcThZmZ5fpfPuqcILzEFJoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAjN0lEQVR4nO3deZRcVbn38e8vnQgiswRkDgoOASREBFHAyKCIQ+ReQniVIKJGFJyurCu+siSgLAdEERUhat6gIOMVDcg1JEECIgIBQkgCwYgJCQSZAkaQSHc/7x9ntx6a7tPV3afqdFX/Pqyz6gy7znl2Famn995nUERgZmbWmxFVB2BmZkObE4WZmRVyojAzs0JOFGZmVsiJwszMCjlRmJlZIScKGzRJB0paVnUcrUDSEkkTqo7DLM+JwmomaYWkQ7uvj4ibI+J1VcTUnaRpkl6Q9HdJT0v6g6T9q46rVhGxe0TcWHUcZnlOFNa0JI3sZdPlEbExsBXwO+DKOhxbkvzvx4YF/49ugyZpgqTVueUVkk6RtEjSM5Iul7Rhbvt7JS3M/cX/xty2UyX9WdI6SUslHZnbdrykWyR9V9KTwLSiuCKiHbgE2F7S6LSPzST9VNIaSQ9L+pqktrStTdI5kp6Q9BdJJ0uKroQk6UZJZ0m6BXgOeLWk10uaI+kpScskHZ2L94hUh3XpWKek9VtJujbV/ylJN3clnXyrTdIGks6V9EiazpW0Qf4zl/QFSY+l+nxkYN+gWTEnCquXo4HDgV2ANwLHA0jaG5gBfAJ4JXAhMKvrBxD4M3AgsBlwBnCxpG1z+90PeBDYBjirKABJLwOOA54E1qbVM4F2YFdgb+CdwMfSto8D7wbGAeOBD/Sw2ynAVGAT4HFgDvALYGvgGOB8SWNT2Z8Cn4iITYA9gBvS+i8Aq4HRqR7/F+jpXjpfBt6S4tkL2Bc4Lbf9VWSf0/bAR4EfStqi90/EbGCcKKxezouIRyLiKeAash87yH5kL4yI2yKiIyIuAtaT/SASEVem93VGxOXAn8h+ILs8EhHfj4j2iPhHL8c+WtLTwD/IfvyPioh2SdsARwCfi4hnI+Ix4LtkP/CQJbfvRcTqiFgLfKOHfc+MiCWptXI4sCIi/l+K527gf4BJqewLwFhJm0bE2oi4K7d+W2DniHghjfH0lCg+BJwZEY9FxONkiXNKbvsLafsLEXEd8HdgSIwVWWtxorB6eTQ3/xywcZrfGfhC6nZ5Ov2g7whsByDpuFy31NNkf4lvldvXqhqOfUVEbE721/pi4E25Y48C1uT2fyFZa4AUQ37/PR0rv25nYL9udfkQ2V/6AP9JlphWSpqfG1Q/G1gOXC/pQUmn9lKP7YCVueWVaV2XJ1PC6pL/nM1K09tgoFm9rALOioiXdBtJ2hn4MXAIcGtEdEhaCChXrObbHUfEE5KmAgsk/SIdez2wVbcf2C5rgB1yyzv2tNtudZkfEYf1cvw7gImSRgEnA1cAO0bEOrLupy9I2gO4QdIdETGv2y4eIUtGS9LyTmmdWUO5RWH9NUrShrmpv39s/Bg4UdJ+6cyhV0h6j6RNgFeQ/RA/DpAGZ/cYTLARsQyYDfx3RKwBrgfOkbSppBGSXiPp7an4FcBnJW0vaXPgi33s/lrgtZKmSBqVpjdLeoOkl0n6kKTNIuIF4G9AZ6rXeyXtKknAM0BH17ZuLgVOkzRa0lbAV4CLB/N5mA2EE4X113Vkff9d07T+vDkiFpCNG/yAbIB5OWmgOyKWAucAtwJ/BfYEbikh5rOBqZK2JhvcfhmwNB3/KrLxAsiS2PXAIuBusrq2k/2Q91SXdWSD4ceQ/aX/KPBNoGtgfgqwQtLfgBPJuqUAdgPmko0p3AqcHxG/6+EQXwMWpHjuBe5K68waSn5wkVnPJL0buCAidq46FrMquUVhlkh6ebr2YaSk7YHTgaurjsusam5RmCWSNgLmA68n61b7DfDZiPhbpYGZVcyJwszMCrnryczMCg2f6yhuvrnlmk5Pjh/bd6EmtGj1oqpDqIvrl1xfdQilO2xsj5eQNL2DX3+w+i5VQKr99yZicMdqgOGTKMzMGmVEa3XWOFGYmZVNQ76R0C9OFGZmZXOLwszMCjlRmJlZoba2qiMolROFmVnZ3KIwM7NCThRmZlbIicLMzAq12Omxlac9STMlHVV1HGZmpRkxovapD5JmSHpM0uLcummSHk6PDV4o6Yjcti9JWi5pmaR3lVGdSlsUA3g6mpnZ0FfuWU8zyR709bNu678bEd/Or5A0luxBWruTPV99rqTXRkSPD9+qVd1aFJLGdMuAp6QseKOkcyUtAD6bNh8qaYGkByS9N/f+myXdlaa3pvUT0j6uknS/pEvSIyXNzIaGtrbapz5ExE3AUzUeeSJwWUSsj4i/kD1Bct+BVyRTVdfTyyJin4g4Jy2PIavMe4ALJG0IPAYcFhHjgcnAebn37w18DhgLvBp4W4PiNjPrm1TzJGlq+kO5a5pa41FOlrQodU1tkdZtD6zKlVmd1g1KVYni8m7LV0REZ0T8CXiQ7MExo4AfS7oXuJIsKXS5PSJWR0QnsJAs0bxE/guYPmtW2XUwM+tZP8YoImJ6+sO5a5pewxF+BLwGGAesIXvWfN3Uc4ygnRcnog1z8892K9v9lrwBfB74K7BX2s/zue3rc/Md9FKP9IFnH3oL3mbczIaoOp8eGxF/7ZqX9GPg2rT4MLBjrugOad2g1LM2fwW2lvRKSRsA7y0oO0nSCEmvIetKWgZsBqxJrYYpQGtdE29mravEMYqeSNo2t3gk0DUePAs4RtIGknYBdgNuH1RdqGOLIiJekHQmWZAPA/cXFH8oldsUODEinpd0PvA/ko4DfstLWyFmZkNTiS0KSZcCE4CtJK0GTgcmSBpH1vuyAvgEQEQskXQFsJSsV+ekwZ7xBMPpmdkt2PXkJ9w1Fz/hrnkM+gl3r31t7b83Dzww5M/a9HUMZmZl8y08zMysUItd2uVEYWZWNrcozMyskB9cZGZmhdyiMDOzQk4UZmZWyInCzMwKOVGYmVkhJ4omdd11VUdQuleOGlV1CHXxjnH7Vx1CXYwc0Xr/3A7ceb+qQxiafNaTmZkVcovCzMwKOVGYmVkh38LDzMwKuUVhZmaFPJhtZmaF3KIwM7NCThRmZlaoxRJF5bWRdKakQ6uOw8ysNCNG1D41gUpbFJLaIuIrVcZgZla6JkkAtapbbSSNkXS/pEsk3SfpKkkbSVoh6ZuS7gImSZop6aj0nhWSvi5poaQFksZLmi3pz5JOTGUmSLox7a9r/6110rKZNbe2ttqnJlDvtPc64PyIeAPwN+BTaf2TETE+Ii7r4T0PRcQ44GZgJnAU8BbgjFyZvYHPAWOBVwNvq0fwZmYD0mJdT/WOclVE3JLmLwYOSPOXF7xnVnq9F7gtItZFxOPAekmbp223R8TqiOgEFgJjetqRpKmpZbJg+sKFA6+FmVl/OFH0S/Sy/GzBe9an187cfNfyyG5lADroZawlIqZHxD4Rsc/UceNqCtjMbNCk2qcmUO9EsZOkrntGfxD4fZ2PZ2ZWPbco+mUZcJKk+4AtgB/V+XhmZtVrsURR79Nj2yPi2G7rxuQXIuL43PyY3PxMssHs7ttuTFPX+pPLCNTMrDRNcjZTrXxltplZ2ZqkpVCrutUmIlZExB712r+Z2ZBVYteTpBmSHpO0OLduS0lzJP0pvW6R1kvSeZKWS1okaXwp1SljJ2ZmllPuGMVM4PBu604F5kXEbsC8tAzwbmC3NE2lpHFhJwozs7KVmCgi4ibgqW6rJwIXpfmLgA/k1v8sMn8ENpe07aCrM9gdmJlZN/24hUf+wuA0Ta3hCNtExJo0/yiwTZrfHliVK7c6rRsUD2abmZWtH4PZETEdmD7QQ0VESOp+cXOpnCjMzMpW/7Oe/ipp24hYk7qWHkvrHwZ2zJXbIa0bFHc9mZmVrf638JgFfDjNfxj4dW79censp7cAz+S6qAbMLQozs7KV2KKQdCkwAdhK0mrgdOAbwBWSPgqsBI5Oxa8DjgCWA88BHyklhoi6dm0NHXXuw6vE+99fdQT1sddeVUdQH4cdVnUE5Zs3r+oI6mPatMHdre+//qv235vvfGfI3xnQLQozs7L5Fh5mZlaoxW7h4URhZlY2JwozMyvkRGFmZoWcKMzMrFCTPOK0Vk4UZmZlG9laP62tVRszs6GgxbqehlRtJJ0p6dB+vudsSUsknV2vuMzM+qX+t/BoqCHTopDUFhFfGcBbpwJbRkRH2TGZmQ2IWxT9J2mMpPslXSLpPklXSdpI0gpJ35R0FzBJ0kxJR6X3rJD0dUkL0z3ax0uaLenPkk5MZWYBGwN3SprciLqYmfWp3CfcVa6RLYrXAR+NiFskzQA+ldY/GRHjASR1f9zfQxExTtJ3yR4H+DZgQ2AxcEFEvF/S3yNiXENqYGZWixa7hUcj09mqiLglzV8MHJDmLy94z6z0ei9wW0Ssi4jHgfWSNu/rgPknRw34qSBmZv3lFsWAdb+bYtfyswXvWZ9eO3PzXct9xv6iJ0e14t1jzWxoapIEUKtG1mYnSfun+Q8Cv2/gsc3MGqfFznpqZKJYBpwk6T5gC+BHDTy2mVnjtLXVPjWBRnY9tUfEsd3WjckvRMTxufkxufmZZIPZPW3buMwgzcwGrUlaCrUaMtdRmJm1DN/Co/8iYgWwRyOOZWZWObcozMysUIud9eREYWZWNicKMzMr5ERhZmaFPEZhZmaFfNaTmZkVcteTmZkVctdTkzr99KojKN/EiVVHUB/jxlUdQV3MvX9e1SGU7pBpLfjvChj0z7xbFGZmVsiJwszMCpU8mC1pBbAO6CC7b94+krYke57PGGAFcHRErC31wElrpT0zs6GgPrcZf0dEjIuIfdLyqcC8iNgNmJeW68KJwsysbI15wt1E4KI0fxHwgcGG3RsnCjOzsvUjUeQf2ZymqT3sMYDrJd2Z275NRKxJ848C29SrOh6jMDMrWz9aCi96ZHPvDoiIhyVtDcyRdH+3fYTq+LhntyjMzMpW8hhFRDycXh8Drgb2Bf4qadvscNoWeKxOtXGiMDMr3ciRtU99kPQKSZt0zQPvBBYDs4APp2IfBn5dp9o0T9eTpJnAtRFxVdWxmJkVKvc6im2Aq5W1PkYCv4iI30q6A7hC0keBlcDRZR40r2kShZlZ0yjxFh4R8SCwVw/rnwQOKe1ABeqWKFIT6QpgB6AN+CqwHPgOsDHwBHB8RKyRtCtwATCa7IKSScCDwPeBw4BVwD9z+15BdjrY+4BRwKSIeNHgjplZZXxlds0OBx6JiPcASNoM+F9gYkQ8LmkycBZwAnAJ8I2IuFrShmRjJ0cCrwPGkjW9lgIzcvt/IiLGS/oUcArwsTrWxcysdi2WKOpZm3uBwyR9U9KBwI7AHmSndi0ETgN2SIM020fE1QAR8XxEPAccBFwaER0R8QhwQ7f9/zK93kl2CftL5M9Pnn7nnSVXz8ysFyUOZg8FdYsyIh6QNB44Avga2Q/9kojYP1+uazR/ANan1w56qceLzk+eNq1u5xibmb1Ii91mvG4tCknbAc9FxMXA2cB+wGhJ+6ftoyTtHhHrgNWSPpDWbyBpI+AmYLKktnSO8DvqFauZWakacwuPhqlnu2dP4GxJncALwCeBduC8NF4xEjgXWAJMAS6UdGYqO4nsopKDycYmHgJurWOsZmblaZIEUKt6dj3NBmb3sOmgHsr+iSwpdHdyL/sek5tfAEwYUJBmZvUwHBOFpF2AT5MNGv/rPRHx/vqEZWbWxFpsjKLWFsWvgJ8C1wCddYvGzKwVNMnZTLWqtTbPR8R5dY3EzKxVDMeuJ+B7kk4Hruffp6USEXfVJSozs2Y2TLue9iQ7M+lg/t31FPQ8AG1mNrwN0xbFJODVEfHPPkuamQ13LZYoaq3NYmDzOsZhZtY6Sn5wUdVqbVFsDtyf7n+eH6Pw6bFmZt0N07OeTq9rFGZmraTFup5qShQRMV/SNsCb06rb07Nbm8e8eVVHUL6NN646gvp4/PGqI6iLQ955WNUhlE5zW/DfFcChhw7u/S2WKGqqjaSjgdvJBrWPBm6TdFQ9AzMza1rD9KaAXwbe3NWKkDQamAv4+dVmZt01ySB1rWpNFCO6dTU9SX0femRm1ryG6WD2byXNBi5Ny5OB6+oTkplZk2uSLqVa9ZkoJAk4j2wg+4C0enrXo0vNzKyb4db1FBEh6bqI2JN/P6fazMx602Itilprc5ekN/ddzMzMhutZT/sBx0paATwLiKyx8cZ6BWZm1rSGU9eTpJ0i4iHgXQ2Kx8ys+bXYWU99tXt+BRARK4HvRMTK/FT36HohaWbXBX+SDpS0RNJCSS+vKiYzs39psa6nvqLMt59eXc9ABuFDwNcjYlxE/KPqYMzMyk4Ukg6XtEzSckmn1jn6l+gryuhlvl8kvULSbyTdI2mxpMmS3iRpvqQ7Jc2WtG0qu6ukuansXZJeo8wP0gc1F9g6lf0Y2S1FvirpkoHGZ2ZWqhIThaQ24IfAu4GxwP+RNLbONXiRvjrS9pL0N7KWxcvTPPx7MHvTGo9zOPBIRLwHQNJmwP8CEyPicUmTgbOAE4BLgG9ExNWSNiRLZkcCryP7kLYBlgIzIuInkg4Aro0I307EzIaGcgez9wWWR8SD2a51GTCR7HewIQoTRUS0lXSce4FzJH0TuBZYC+wBzMmu56MNWCNpE2D7rov5IuJ5AEkHAZdGRAfwiKQbajmopKnAVIALd92Vqa96VUnVMTMrUO7Yw/bAqtzyarIzURumIUPzEfGApPHAEcDXgBuAJRGxf75cShRlHnc6MB2AAw8ccNeZmVl/dERnzWVHjhj5rz9ok+npt2vIaMiQu6TtgOci4mLgbLJsOFrS/mn7KEm7R8Q6YLWkD6T1G0jaCLgJmCypLY1lvKMRcZuZDURE9GeaHhH75KbuSeJhYMfc8g5pXcM06mTfPYGzJXUCLwCfBNqB89J4xUjgXGAJMAW4UNKZqewk4GrgYLI+uYeAWxsUt5lZv3X2o0VRgzuA3STtQpYgjgE+WOYB+tKorqfZwOweNh3UQ9k/kSWF7k7uZd/HDyo4M7OSlZkoIqJd0slkv6FtZCfyLCntADVorcsHzcyGgIhyh0Qj4joqfLSDE4WZWcnaO9urDqFUThRmZiUreYyick4UZmYlc6IwM7NCThRmZlao7MHsqjlRmJmVzC0KMzMr1N7hs56a02GHVR1B+VqxTkDs1ZpP2J2zdE7VIZTukIMPqTqEuhjs3VDd9WRmZoXc9WRmZoWcKMzMrJC7nszMrJBbFGZmVsj3ejIzs0JuUZiZWSEnCjMzK+TBbDMzK+QWhZmZFfItPAZIkgBFtFiqNTPrptW6nkbUc+eSxkhaJulnwGLgp5IWSFoi6YxcuRWSzpB0l6R7Jb0+rR8taU4q/xNJKyVtlbYdK+l2SQslXShpsLdnMTMrRWc//msGdU0UyW7A+RGxO/CFiNgHeCPwdkn5u789ERHjgR8Bp6R1pwM3pPdeBewEIOkNwGTgbRExDugAPtSAupiZ9amzs7PmqRk0IlGsjIg/pvmjJd0F3A3sDozNlftler0TGJPmDwAuA4iI3wJr0/pDgDcBd0hamJZf3f3AkqamFsyC6QsWlFYhM7MiEVHz1AwaMUbxLICkXchaCm+OiLWSZgIb5sqtT68dNcQl4KKI+FJRoYiYDkwH4Mwzm+MbMbOm12pnPTWiRdFlU7Kk8YykbYB31/CeW4CjASS9E9girZ8HHCVp67RtS0k7lx+ymVn/tXe21zw1g4ad9RQR90i6G7gfWEWWBPpyBnCppCnArcCjwLqIeELSacD1kkYALwAnASvrE72ZWe1arUVR10QRESuAPXLLx/dSbkxufgEwIS0+A7wrItol7U/WbbU+lbscuLwecZuZDYYTRWPtBFyRWg3/BD5ecTxmZn1qlkHqWg3pRBERfwL2rjoOM7P+aLUWRSMHs83MhoX2jvaap8GQNE3Sw+nC44WSjsht+5Kk5emi53cN5jhDukVhZtaMGtz19N2I+HZ+haSxwDFk16ttB8yV9NqI6BjIAdyiMDMr2RC4hcdE4LKIWB8RfwGWA/sOdGdOFGZmJevPLTzyd5BI09R+Hu5kSYskzZDUda3Z9mSXIXRZndYNiLuezMxK1p+upxfdQaIHkuYCr+ph05fJ7o33VSDS6znACf2JtRZOFGZmJSvzrKeIOLSWcpJ+DFybFh8Gdsxt3iGtG5Dhkyj22qvqCEoXe72x70JNaNHqRVWHUBf3rLqn6hBKN3rj0VWHUBd77zS4s/IbdWsOSdtGxJq0eCTZ4xwAZgG/kPQdssHs3YDbB3qc4ZMozMwapIHXUXxL0jiyrqcVwCcAImKJpCuApUA7cNJAz3gCJwozs9I1KlFExJSCbWcBZ5VxHCcKM7OS+RYeZmZWqNVu4eFEYWZWMicKMzMr1NE54HHjIcmJwsysZG5RmJlZoc5OJwozMyvgs54qJGkC8M+I+EPFoZiZ9cpdT9WaAPwdeEmikDQyIhpz3byZWYFG3cKjURp2m3FJYyTdL+kSSfdJukrSRpK+IukOSYslTZekVP4zkpam2+deJmkMcCLw+fQkpwMlzZR0gaTbgG81qi5mZkUiouapGTS6RfE64KMRcYukGcCngB9ExJkAkn4OvBe4BjgV2CUi1kvaPCKelnQB8PeupzlJ+ijZXRHfOpj7mJiZlamjxX6OGv3golURcUuavxg4AHiHpNsk3QscTPboPoBFwCWSjiW7qVVvruwtSeQfCDJ99uySqmBmVswtisHp/qkEcD6wT0SskjQN2DBtew9wEPA+4MuS9uxln8/2erD8A0F+/evm+EbMrOm12mB2o1sUO0naP81/EPh9mn9C0sbAUQCSRgA7RsTvgC8CmwEbA+uATRobsplZ/3RGZ81TM2h0i2IZcFIan1hK9hi/LcgetvEocEcq1wZcLGkzQMB5aYziGuAqSROBTzc4djOzmvgWHoPTHhHHdlt3Wpq6O6D7ioh4AMg/1u3mEmMzMytFs7QUatVs11GYmQ15voXHAEXECmCPRh3PzKwqzXI2U63cojAzK5m7nszMrJAThZmZFfJZT2ZmVsgtCjMzK+REYWZmhZwozMyskBNFk4qJ7686hNJds/CaqkOoi4WrFlYdQl3MWTqn6hBK9+z6Xu/J2dT23mnvQb3fg9lmZlbILQozMyvUarfwaPRtxs3MWl6jHlwkaZKkJZI6Je3TbduXJC2XtEzSu3LrD0/rlks6tZbjuEVhZlayBnY9LQb+A7gwv1LSWOAYsieGbgfMlfTatPmHwGHAauAOSbMiYmnRQZwozMxK1qhEERH3AUjqvmkicFlErAf+Imk5sG/atjwiHkzvuyyVdaIwM2uk/pz1JGkqMDW3anp6jPNgbA/8Mbe8Oq0DWNVt/X597cyJwsysZP1pUaSk0GtikDQXeFUPm74cEb/uf3T950RhZlayMrueIuLQAbztYWDH3PIOaR0F63vls57MzErWGZ01T3UyCzhG0gaSdgF2A24H7gB2k7SLpJeRDXjP6mtnQ7ZFIWlkRLRXHYeZWX81ajBb0pHA94HRwG8kLYyId0XEEklXkA1StwMnRURHes/JwGygDZgREUv6Ok6liULSccApQACLgA7geWBv4BZJPwMuADYC/gycEBFrJd0I3AO8nawOJ0TE7Y2vgZnZSzXqUagRcTVwdS/bzgLO6mH9dcB1/TlOZYlC0u7AacBbI+IJSVsC3yHrM3trRHRIWgR8OiLmSzoTOB34XNrFRhExTtJBwAz8PG4zGyLaO1urM6TKMYqDgSsj4gmAiHgqrb8yJYnNgM0jYn5afxFwUO79l6b33QRsKmnz7geQNFXSAkkLpk8f7NlmZma16ezsrHlqBkNxjKLW21F2b9u9pK2XP+0saFBb0MyGvXjpz1FTq7JFcQMwSdIrAVLX079ExDPAWkkHplVTgPm5IpPT+w4Anknlzcwq5xZFSdKo/FnAfEkdwN09FPswcIGkjYAHgY/ktj0v6W5gFHBC3QM2M6uRbzNeooi4iGzsobftC4G39LL54oj4XB3CMjMbFD+4yMzMCrlFMQRExISqYzAz640ThZmZFXKiMDOzQk4UZmZWqFG38GgUJwozs5K12i08nCjMzErWLBfS1cqJwsysZK12Cw8nCjOzkrVai0KtNugyFEiaWsLD0YeUVqwTtGa9WrFO0Lr1agZ+FGp9TK06gDpoxTpBa9arFesErVuvIc+JwszMCjlRmJlZISeK+mjFftRWrBO0Zr1asU7QuvUa8jyYbWZmhdyiMDOzQk4UZmZWyInCBkzSBElvrToOq52kmZKOSvMHSloiaaGkl1cd20Dl62T14URREknD8Sr3CUCPiaLKz0MZ/7/dtw8BX4+IcRHxj6qDsaHL/5j6QdJxkhZJukfSz9NfMhdIug34lqRxkv6YylwtaYv0vhslfS/95bZY0r4VVwVJYyTdL+kSSfdJukrSRpK+IumOFOd0SUrlPyNpaarbZZLGACcCn0/1OrD751FBfZZJ+hmwGPippAXpL+YzcuVWSDpD0l2S7pX0+rR+tKQ5qfxPJK2UtFXadqyk21M9L5TU1sB6vULSb9L/c4slTZb0JknzJd0pabakbVPZXSXNTWXvkvSalDR/kD6bucDWqezHgKOBr0q6pFH1qWedUvkev18bpIjwVMME7A48AGyVlrcEZgLXAm1p3SLg7Wn+TODcNH8j8OM0fxCweAjUZwwQwNvS8gzgFGDLXJmfA+9L848AG6T5zdPrNOCUXPkXfR4V1KcTeEvX95Ne29Ln/8a0vAL4dJr/FPCTNP8D4Etp/vD02WwFvAG4BhiVtp0PHNfAev1n1/87aXkz4A/A6LQ8GZiR5m8DjkzzGwIbAf8BzEmfw3bA08BRue/rqAq+q3rWqcfv19PgpuHYXTJQBwNXRsQTABHxVPpj+8qI6JC0GdkP6PxU/iLgytz7L03vu0nSppI2j4inGxd+j1ZFxC1p/mLgM8BfJP032T/ILYElZD+Ui4BLJP0K+FXBPq+MiI66RVxsZUT8Mc0fLWkq2Y0vtwXGktUB4Jfp9U6yHx2AA4AjASLit5LWpvWHAG8C7kjf98uBx+pZiW7uBc6R9E2yJLwW2AOYk+JpA9ZI2gTYPiKuTnV4HkDSQcCl6Tt5RNINDYy9N/WuU0/frw2CE8XgPVtjue4XrAyFC1h6iul8YJ+IWCVpGtlfcQDvIWsNvQ/4sqQ9e9lnrZ9HPTwLIGkXstbRmyNiraSZ/LseAOvTawd9/xsQcFFEfKnkWGsSEQ9IGg8cAXwNuAFYEhH758ulH9Wm0IA69ef7tRp4jKJ2NwCTJL0SQNKW+Y0R8QywVtKBadUUYH6uyOT0vgOAZ1L5qu0kqesf5weB36f5JyRtDHSdHTMC2DEifgd8kayrYGNgHTAUf6A2JUsaz0jaBnh3De+5hazPHknvBLZI6+cBR0nq6tvfUtLO5YfcM0nbAc9FxMXA2cB+wOiu703SKEm7R8Q6YLWkD6T1G0jaCLgJmCypLfX7v6NRsfemFevU6pxtaxQRSySdBcyX1AHc3UOxDwMXpP+ZHwQ+ktv2vKS7gVHACXUPuDbLgJMkzQCWAj8i+4FcDDwK3JHKtQEXp+41AedFxNOSrgGukjQR+HTDo+9FRNyTPuv7gVVkSaAvZwCXSpoC3EpW/3UR8YSk04DrU8J8ATgJWFmf6F9iT+BsSZ3p2J8E2oHz0vcxEjiXrItwCnChpDNT2UnA1WTdpkuBh1LdqtaKdWppvoVHA0i6kWzQd0HVsXRRdtbStRGxR9WxDAWSNgA6IqI9/WX7o4gYV3FYZkOCWxRmmZ2AK1Kr4Z/AxyuOx2zIcIvCzMwKeTDbzMwKOVGYmVkhJwozMyvkwWwbNtI1MPPS4qvILsh6PC3vGxH/rCQwsyHOg9k2LKWrzv8eEd+uOhazoc5dTzasSTpE0t3pTqMz0vUUZpbjRGHD2YZkd1CdHBF7knXFfrLSiMyGICcKG87agL9ExANp+SKyGx+aWY4ThZmZFXKisOGsAxgjade03P2Ov2aGE4UNb8+T3eH3Skn3kj0h74JqQzIbenx6rJmZFXKLwszMCjlRmJlZIScKMzMr5ERhZmaFnCjMzKyQE4WZmRVyojAzs0L/H2fOVSWeHiF2AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEWCAYAAABmE+CbAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAhD0lEQVR4nO3deZgdVbnv8e8vnTCGUWIMQwzITICAgIABGQXFCHgIUQRE9OSgiNdzD/eoVy9ClEcRBwQPQ4t5AicchoBBUAHBCJHIFCCSBMIcCHOiDCGQQLrf+0etlqLpYXe69q69d/8+z1PPrmFV1bu6k/32WlW1ShGBmZnZoLIDMDOz+uCEYGZmgBOCmZklTghmZgY4IZiZWeKEYGZmgBOCNShJp0uaWnYcZs3ECcEKI2mhpDclvS7pBUlTJA0tO67+kLSfpPZUp47p+hqef5SkkDS4Vue0gcsJwYo2LiKGAmOAXYBvlxtOIZ6LiKG5aVxfDyCppRqBmRXJCcGqIiJeAG4iSwwASPqWpMclLZX0oKQjc9tOkHS7pJ9IelnSk5I+kdu+uaTb0r43Axvlzyfp05LmS3pF0q2StsttWyjp/0h6QNIySb+WNFzSDel4t0jaoK91lLRdOtcr6dyfzm2bIukCSX+QtAzYX9LGkq6RtDjV7+u58ntImi3pNUkvSvpZ2jQzfb6SWid79TVOs0o5IVhVSNoU+ATwWG7148A+wHrAGcBUSSNy2z8CPEz2Zf9j4NeSlLb9D3Bv2vZ94Au5c20NXA58AxgG/AG4XtJquWP/C3AwsDUwDrgB+L+p/CDg6/SBpCHA9cAfgfcDpwCXSdomV+wY4ExgHeCvqfzfgE2AA4FvSDoklf0F8IuIWBf4EHBVWr9v+lw/tU7u6EucZn3hhGBFu1bSUmAR8BLwvY4NETEtIp6LiPaIuBJ4FNgjt+9TEfGriGgDLgFGAMMljQR2B/5fRKyIiJlkX64dJgC/j4ibI+Jt4CfAmsDeuTLnRcSLEfEs8Bfgroi4PyKWA9PJure6s3FqBXRMRwN7AkOBH0XEWxExA/gd8Lncfr+NiFkR0Q7sCAyLiEmp/BPAr4DPprJvA1tK2igiXo+IO3v8KZtVgROCFe2IiFgH2A/YllzXjqTjJc3p+GIFRvPurp8XOmYi4o00OxTYGHg5Ipblyj6Vm984v5y+gBeR/SXe4cXc/JtdLPd08fu5iFg/N12VzrkonSsfU/6ci3LzH6RTYiFroQxP279E1npZIOkeSZ/qIR6zqvCdC1YVEXGbpClkf60fIemDZH8RHwjcERFtkuYA6v4o//Q8sIGktXNJYSTQMVTvc2R/gQOQupk2A54toi7deA7YTNKgXFIYCTySK5MfSngR8GREbNXVwSLiUeBzkgYBnwGulvS+Tscwqyq3EKyazgEOlrQzsDbZl9tiAElfJGsh9CoingJmA2dIWk3SWLLrAB2uAg6TdGDq2/8PYAVZv3213AW8AfynpCGS9ksxXdFN+buBpZK+KWlNSS2SRkvaHUDSsZKGpeTyStqnnezn1Q5sUb2qmGWcEKxqImIxcClwWkQ8CPwUuIOsu2ZHYFYfDncM2UXnf5Bdl7g0d56HgWOB84AlZF/M4yLirQKq0aV07HFkF86XAOcDx0fEgm7KtwGfIrvr6sm0z8VkF9gBDgXmS3qd7ALzZyPizdR1diYwK3U17VmtOpnJL8gxMzNwC8HMzBInBDMzA5wQzMwscUIwMzNgID2HMGdO810936rLW9qtTs1e8lDZIRRuxHojei/UgDZZf5NKno/p3rBhlX/fLF7cv3MVaOAkBDOzWhnUmJ0vTghmZkVraczRzp0QzMyK5haCmZkBTghmZpa4y8jMzAC3EMzMLHFCMDMzwAnBzMySBk0IpUctaYqko8qOw8ysMIMGVT7VkVJbCJLcQjGz5tOgdxlVLT1JGiVpXm75VEmnS7pV0jmSZgP/K20+SNJsSY90vFw87f8XSfelae+0fr90jKslLZB0WXqHrplZfXALoU9Wi4jdIOsyAkYBewAfAv4saUvgJeDgiFguaSvgcmC3tP8uwA5kLzqfBXwUuL2WFTAz65ZbCH1yZaflqyKiPSIeBZ4AtgWGAL+SNBeYBmyfK393RDyTXkg+hyyhvIekianlMbv1mmuKroOZWdfcQniPlbw74ayRm1/WqWznoWID+Heyl7HvnI6zPLd9RW6+jW7qERGtQCvQnMNfm1l9atBe7GqmpxeB90t6n6TVgU/1UHa8pEGSPgRsATwMrAc8n1oBxwGN2QYzs4Fn8ODKpzpStWgi4m1Jk4C7gWeBBT0UfzqVWxc4KV03OB+4RtLxwI28t1VhZlaf6qwrqFKKGCA9Kc3YZeQ3pjUUvzGtcfT7jWn77lv5983MmXXTv1Rf7RUzs2bQoC0EJwQzs6I5IZiZGeCEYGZmSYM+mOaEYGZWNLcQzMwMcAvBzMwStxDMzAxo2KErnBDMzIrmFkKdu+mmsiMo3ltvlR1BdWywQdkRVMVmwzcrO4TCDR86rOwQ6lOdjVFUqcaM2sysnjVoC6ExozYzq2cFvg9B0mRJL3V6A+WGkm6W9Gj6LKRZ7YRgZla0Yl+QMwU4tNO6bwF/ioitgD+l5f6HXcRBzMwsp8CEEBEzgX90Wn04cEmavwQ4ooiwfQ3BzKxofXgwTdJEYGJuVWt622NPhkfE82n+BWB43wLsmhOCmVnR+pAQ3vWq31UQESGpkPe9OCGYmRWt+ncZvShpREQ8L2kE8FIRB/U1BDOzokmVT6vmOuALaf4LwG+LCLv0hCBpkqSDyo7DzKwwxd52ejlwB7CNpGckfQn4EXCwpEeBg9Jyv5XaZSSpJSJOKzMGM7PCFdhlFBGf62bTgYWdJKlaC0HSKEkLJF0m6SFJV0taS9JCSWdJug8YL2mKpKPSPgsl/VDSHEmzJe0q6SZJj0s6KZXZT9Kt6Xgdx2/MkaTMrDkNHlz5VEeq3WW0DXB+RGwHvAZ8Na3/e0TsGhFXdLHP0xExBvgL2QMZRwF7AmfkyuwCfAPYHtgC+Gg1gjczWyXFPphWM9WOZlFEzErzU4Gxaf7KHva5Ln3OBe6KiKURsRhYIWn9tO3uiHgmItqBOcCorg4kaWJqacxuveuuflTDzKwPGjQhVLu90vne2I7lZT3ssyJ9tufmO5YHdyoD0EY39XjX/b1nnVXIfbpmZr2qsy/6SlU76pGS9krzxwC3V/l8Zmbla9AWQrWjeRg4WdJDwAbABVU+n5lZ+ar/HEJVVLvLaGVEHNtp3aj8QkSckJsflZufQnZRufO2W9PUsf5rRQRqZlaYIUPKjmCV1Nc9T2ZmzaDOuoIqVbWEEBELgdHVOr6ZWd2qs66gSrmFYGZWNLcQzMwMcEIwM7OkzoakqFRjRm1mVs/cQjAzM8AJwczMEicEMzMDfNtp3XvkkbIjKN5DD5UdQXW8+WbZEVTF8Bkzyg6heFOmlB1BdRx2WP/2dwvBzMwAD11hZmaJu4zMzAxwl5GZmSVOCGZmBjghmJlZ4oRgZmaAxzIyM7OkQVsIdRW1pEmSDurjPmdLmi/p7GrFZWbWJ4MGVT7VkbppIUhqiYjTVmHXicCGEdFWdExmZqukQZ9DqEl6kjRK0gJJl0l6SNLVktaStFDSWZLuA8ZLmiLpqLTPQkk/lDRH0mxJu0q6SdLjkk5KZa4DhgL3SppQi7qYmfWq4BZC+j6c2/F9WK2wa9lC2Ab4UkTMkjQZ+Gpa//eI2BVA0qGd9nk6IsZI+jkwBfgosAYwD7gwIj4t6fWIGFOTGpiZVaI6Q1fsHxFLqnHgDrXswFoUEbPS/FRgbJq/sod9rkufc4G7ImJpRCwGVkhav7cTSpqYWhezWxcsWNW4zcz6Rqp8qiO1TAjRzfKyHvZZkT7bc/Mdy722biKiNSJ2i4jdJm67bcWBmpn1Sx+6jPJ/uKZpYhdHDOCPku7tZnshatllNFLSXhFxB3AMcDuwSw3Pb2ZWG324eygiWoHWXoqNjYhnJb0fuFnSgoiY2Z8Qu1LLFsLDwMmSHgI2AC6o4bnNzGqn4IvKEfFs+nwJmA7sUY2wa9lCWBkRx3ZaNyq/EBEn5OZH5eankF1U7mrb0CKDNDPrtwKfL5C0NjAoIpam+Y8Dkwo7QU7dPIdgZtY0ih26YjgwXdkF6MHA/0TEjUWeoENNEkJELARG1+JcZmalK7CFEBFPADsXdsAeuIVgZla0OrudtFJOCGZmRauzMYoq5YRgZlY0JwQzMwOgpaXsCFaJE4KZWdGcEMzMDHCXkZmZJU4IdW7//cuOoHhjxpQdQXVsuWXZEVTF4reXlh1C4YatM6zsEOqTE4KZmQFOCGZmlhQ7dEXNNGbUZmb1zC0EMzMDPHSFmZklbiGYmRnghGBmZomfVDYzM6BhE0LDtGskTZF0VNlxmJn1quB3KteKWwhmZkWrsy/6SlUtIaSXQV8FbAq0AN8HHgN+BgwFlgAnRMTzkrYELgSGAW3AeOAJ4DzgYGAR8Fbu2AuBS4BxwBBgfEQsqFZdzMz6xAnhPQ4FnouIwwAkrQfcABweEYslTQDOBE4ELgN+FBHTJa1B1pV1JLANsD3ZS6YfBCbnjr8kInaV9FXgVODLVayLmVnlGjQhVDPqucDBks6StA+wGTAauFnSHOC7wKaS1gE2iYjpABGxPCLeAPYFLo+Itoh4DpjR6fi/SZ/3AqO6CkDSREmzJc1undF5dzOzKhk8uPKpjlQtmoh4RNKuwCeBH5B9oc+PiL3y5VJCWBUr0mcb3dQjIlqBVgCmTo1VPI+ZWd806JPKVWshSNoYeCMipgJnAx8BhknaK20fImmHiFgKPCPpiLR+dUlrATOBCZJaJI0AmnD8ajNrSr7L6D12BM6W1A68DXwFWAmcm64nDAbOAeYDxwEXSZqUyo4HpgMHkF07eBq4o4qxmpkVp86+6CuliAHSk9KMXUZ+QU5D8QtyGkr/+nyWLav8+2btteumf6miFoKkzYFTyC7e/nOfiPh0dcIyM2tgDdpCqLTL6Frg18D1QHvVojEzawYFD10h6VDgF2TPdF0cET8q9ARJpQlheUScW40AzMyaToEtBEktwH+RPaT7DHCPpOsi4sHCTpJUmhB+Iel7wB9553ZPIuK+ogMyM2t4xXYZ7QE8FhFPAEi6Ajic7IabQlWaEHYkuxPoAN7pMoq0bGZmeX1ICJImAhNzq1rTM1QdNiEbvqfDM2S38Reu0oQwHtgiIt7qtaSZ2QDXHpVfan3XA7QlqzQhzAPWB16qXihmZs2hLwlhkHptTTxLNvRPh03TusJVmhDWBxZIuod3X0PwbadmZp20tbdVXHbwoF6/hu8Btkq3/z8LfBY4ZpWD6ymWCst9rxonNzNrRu3txd2dHxErJX0NuInsttPJETG/sBPkVPyksqThwO5p8e6IaKzuox12aL4nlQ87rOwIquPPfy47guq4556yIyjenXeWHUF17Llnv54eXrai8ieV1169fp5UruhSuKSjgbvJLi4fDdzl11mamXWtLdoqnupJpV1G3wF272gVSBoG3AJcXa3AzMwaVaOOEVdpQhjUqYvo71T35TpmZg1rZdvKskNYJZUmhBsl3QRcnpYnAH+oTkhmZo2tL7ed1pNeE4IkAeeSXVAem1a3drzy0szM3q1pE0JEhKQ/RMSOvPMeYzMz60ajJoRKrwPcJ2n33ouZmVl7tFc81ZNKryF8BDhW0kJgGdnbhCIidqpWYGZmjarIB9NqqceEIGlkRDwNHFKjeMzMGl5fhq6oJ711GV0LEBFPAT+LiKfyU9Wj64akKR0PxknaR9J8SXMkrVlWTGZmHZq1yyj/SPUW1QykHz4P/DAippYdiJkZUHdPIFeqt4QQ3cz3iaS1gavIhm1tAb4PPAb8DBgKLAFOiIjnJW0JXAgMA9rIhst4AjiP7BVyi4C30nG/TDaUxiGSPhERn1/VGM3MilJvf/lXqreEsLOk18haCmumeXjnovK6FZ7nUOC5iDgMQNJ6wA3A4RGxWNIE4EzgROAy4EcRMV3SGmTdWkcC2wDbA8PJXh03OSIuljQW+F1EeBgNM6sLTTl0RUS0FHSeucBPJZ0F/A54GRgN3Jw990YL8LykdYBNOh56i4jlAJL2BS6PiDbgOUkzKjlp/tV0F40YwcQNNiioOmZm3WvKu4yKEhGPSNoV+CTwA2AGMD8i9sqXSwmhyPO+82q6Zhz+2szq0sr2xhzLqCYD1EnaGHgjXfg9m+y5hmGS9krbh0jaISKWAs9IOiKtX13SWsBMYIKkFkkjgP1rEbeZ2apo1ruMirIjcLakduBt4CvASuDcdD1hMHAOMB84DrhI0qRUdjwwHTiA7NrB08AdNYrbzKzP6u2LvlK16jK6iez1b53t20XZR8m+/Dv7WjfHPqFfwZmZFcwJwczMAF9UNjOzpFGHrnBCMDMrmLuMzMwMaN6hK8zMrI+a8kllMzPrO19UNjMzwNcQzMwsadShKwZOQrjyyrIjKN7WW5cdQXWstlrZEVRF68zWskMo3IljTyw7hKro7xdjo7YQajKWkZnZQFKrsYwknS7p2fTGyDmSPtmf4w2cFoKZWY3U+KLyzyPiJ0UcyAnBzKxg7jIyMzMgew6h0knSREmzc9PEPp7ua5IekDRZUr/eAuYWgplZwfpyl9G7XuTVBUm3AB/oYtN3gAvI3lEf6fOnZK8iXiVOCGZmBStycLuIOKiScpJ+RfaK4lXmhGBmVrBaDV0haUREPJ8WjwTm9ed4TghmZgWr4UXlH0saQ9ZltBD4t/4czAnBzKxgtUoIEXFckcdzQjAzK5iHruiFJAGKaNAbdM3MKuTnELogaZSkhyVdSnax49fpPtv5ks7IlVso6QxJ90maK2nbtH6YpJtT+YslPSVpo7TtWEl3p8e1L5LUUs26mJlVqr29veKpntTiwbStgPMjYgfgPyJiN2An4GOSdsqVWxIRu5LdV3tqWvc9YEba92pgJICk7YAJwEcjYgzQBny+BnUxM+tVrcYyKlotEsJTEXFnmj9a0n3A/cAOwPa5cr9Jn/cCo9L8WOAKgIi4EXg5rT8Q+DBwj6Q5aXmLzifOPwHYOm1aYRUyM+tJX55Urie1uIawDEDS5mR/+e8eES9LmgKskSu3In22VRCXgEsi4ts9FXrXE4Dz5tXXT97Mmla9/eVfqVqOZbQuWXJ4VdJw4BMV7DMLOBpA0seBjnE6/gQcJen9aduGkj5YfMhmZn33dtvbFU/1pGZ3GUXE3yTdDywAFpF92ffmDOBySccBdwAvAEsjYomk7wJ/lDQIeBs4GXiqOtGbmVUuaMwOiaomhIhYCIzOLZ/QTblRufnZwH5p8VXgkIhYKWkvsu6mFanclUATvgbNzBpdvd09VKl6fzBtJHBVagW8BfxryfGYmfWqUa8h1HVCiIhHgV3KjsPMrC+cEMzMDPDQFWZmlvgagpmZAe4yMjOzxAnBzMyA2r0xrWhOCGZmBXMLod4NH152BMVbbbWyI6iKhUsWlh1CVbz42otlh1C4G+beUHYIVTFu53H92r/ehqSo1MBJCGZmNeIuIzMzA9xlZGZmiROCmZkBTghmZpY4IZiZGQAr2zyWkZmZ4RaCmZklvu3UzMyAxm0hDCo7gL6QtJ+kvcuOw8ysJ+3RXvHUH5LGS5ovqV3Sbp22fVvSY5IelnRIJcdrtBbCfsDrwF87b5A0OCIa80qOmTWVGl5Ungd8Brgov1LS9sBngR2AjYFbJG0dEW09HaxmCUHSKOBG4F5gV2A+cDxwKjAOWJPsi/7fIiIkfR04CVgJPAh8Ky23SToWOAX4ErCc7DWbs4D/Xav6mJl1p1ZdRhHxEICkzpsOB66IiBXAk5IeA/YA7ujpeLXuMtoGOD8itgNeA74K/DIido+I0WRJ4VOp7LeAXSJiJ+CkiFgIXAj8PCLGRMRfUrlNgb0jwsnAzOpCX7qMJE2UNDs3TSwghE2ARbnlZ9K6HtU6ISyKiFlpfiowFthf0l2S5gIHkDVxAB4ALkutgZ7aX9O6awblf9Ctl15aUBXMzHrWl4QQEa0RsVtuas0fS9ItkuZ1MR1edNy1vobQ+V6sAM4HdouIRZJOB9ZI2w4D9iXrTvqOpB27Oeaybk+W/WCzH+7ixY15H5iZNZwi36kcEQetwm7PApvlljdN63pU6xbCSEl7pfljgNvT/BJJQ4GjACQNAjaLiD8D3wTWA4YCS4F1ahuymVnf1Oouox5cB3xW0uqSNge2Au7ubadatxAeBk6WNJnsQvEFwAZkV8pfAO5J5VqAqZLWAwScGxGvSLoeuDo1lU6pcexmZhVZ2V6bu4wkHQmcBwwDfi9pTkQcEhHzJV1F9j27Eji5tzuMoPYJYWVEHNtp3XfT1NnYzisi4hFgp9yqv3QuY2ZWthreZTQdmN7NtjOBM/tyvEZ7DsHMrO556IpepNtGR9fqfGZmZWnUoSvcQjAzK1iRdxnVkhOCmVnB2nq/fluXnBDMzArW1u6EYGZm+BqCmZklvoZgZmaAWwhmZpY4IdS7YcPKjqBwN8y7oewQqmLzjTYvO4SqOO23p5UdQuEOHX1o2SFUxbidx/Vr/1oNXVG0gZMQzMxqxE8qm5kZ4C4jMzNLfJeRmZkBbiGYmVnihGBmZoDvMjIzs8TXEMzMDHCXkZmZJU4IBZM0OCIasyPOzAY0J4RVIOl44FQggAeANmA5sAswS9KlwIXAWsDjwIkR8bKkW4G/AR8jq8OJEXF37WtgZvZeTgh9JGkH4LvA3hGxRNKGwM+ATdO6NkkPAKdExG2SJgHfA76RDrFWRIyRtC8wGb+v2czqRKO+IGdQiec+AJgWEUsAIuIfaf20lAzWA9aPiNvS+kuAfXP7X572mwmsK2n9zieQNFHSbEmzW1tbq1UPM7N3aW9vr3iqJ/V4DWFZheU6jx71ntGkIqIVaO1uu5lZNTRql1GZLYQZwHhJ7wNIXUb/FBGvAi9L2ietOg64LVdkQtpvLPBqKm9mVrr2aK94qieltRAiYr6kM4HbJLUB93dR7AvAhZLWAp4AvpjbtlzS/cAQ4MSqB2xmVqF6+6KvVKldRhFxCdm1ge62zwH27Gbz1Ij4RhXCMjPrl5VttbljXtJ44HRgO2CPiJid1o8CHgIeTkXvjIiTejtePV5DMDNraDVsIcwDPgNc1MW2xyNiTF8O1pAJISL2KzsGM7Pu1CohRMRDAJIKOV6ZF5XNzJpSXy4q52+PT9PEgsLYXNL9km7L3ZzTo4ZsIZiZ1bO+tBA63R7/HpJuAT7QxabvRMRvu9nteWBkRPxd0oeBayXtEBGv9RSLE4KZWcGK7DKKiINWYZ8VwIo0f6+kx4Gtgdk97eeEYGZWsLa2coeukDQM+Eca9WELYCuyW/d75IRgZlawWl1UlnQkcB4wDPi9pDkRcQjZMD+TJL0NtAMn5YYH6pYTgplZwWp4l9F0YHoX668Brunr8ZwQzMwK1qhPKivCY74VTdLEdOdA02jGOkFz1qsZ6wTNW6964ucQqqOo+4jrSTPWCZqzXs1YJ2jeetUNJwQzMwOcEMzMLHFCqI5m7OdsxjpBc9arGesEzVuvuuGLymZmBriFYGZmiROCmZkBTgjWD5L2k7R32XFY5SRNkXRUmt9H0nxJcyStWXZsqypfJ+sfJ4SCSBqIT33vB3SZEMr8eSjjf9u9+zzww4gYExFvlh2Mlc//afpA0vGSHpD0N0n/nf4yuVDSXcCPJY2RdGcqM13SBmm/WyX9Iv0lNk/SHiVXBUmjJC2QdJmkhyRdLWktSadJuifF2ar0KiZJX5f0YKrbFemdrScB/57qtU/nn0cJ9XlY0qVkrxX8dXrZyHxJZ+TKLZR0hqT7JM2VtG1aP0zSzan8xZKekrRR2naspLtTPS+S1FLDeq0t6ffp39w8SRMkfTi99OReSTdJGpHKbinpllT2PkkfSsnxl+lncwvw/lT2y8DRwPclXVar+lSzTql8l79fq1BEeKpgAnYAHgE2SssbAlOA3wEtad0DwMfS/CTgnDR/K/CrNL8vMK8O6jMKCOCjaXkycCqwYa7MfwPj0vxzwOppfv30eTpwaq78u34eJdSnHdiz4/eTPlvSz3+ntLwQOCXNfxW4OM3/Evh2mj80/Ww2Int5+fXAkLTtfOD4GtbrXzr+7aTl9YC/AsPS8gRgcpq/Czgyza8BrEX2vt2b089hY+AV4Kjc7+uoEn5X1axTl79fT5VNA7GbY1UdAEyLiCUAEfGP9MfztMjGHF+P7IvytlT+EmBabv/L034zJa0raf2IeKV24XdpUUTMSvNTga8DT0r6T7L/eBsC88m+EB8ALpN0LXBtD8ecFhFlDQb/VETcmeaPVvYqwsHACGB7sjoA/CZ93kv25QIwFjgSICJulPRyWn8g8GHgnvT7XhN4qZqV6GQu8FNJZ5El25eB0cDNKZ4W4HlJ6wCbRDb6JRGxHEDSvsDl6XfynKQZNYy9O9WuU1e/X6uAE0L/LauwXOcHPurhAZCuYjof2C0iFkk6neyvMoDDyFo344DvSNqxm2NW+vOohmUAkjYna+3sHhEvS5rCO/WA9CYpoI3e/w8IuCQivl1wrBWJiEck7Qp8EvgBMAOYHxF75culL8+GUIM69eX3azm+hlC5GcB4Se8DkLRhfmNEvAq8rHdeZn0ccFuuyIS031jg1VS+bCMldfwnPAa4Pc0vkTQU6LgbZRCwWUT8GfgmWRN/KLAUqMcvonXJksOrkoYDn6hgn1lkfepI+jiwQVr/J+AoSR197xtK+mDxIXdN0sbAGxExFTgb+AgwrOP3JmmIsnflLgWekXREWr+6pLWAmcAESS2pX37/WsXenWasU7Nw9qxQRMyXdCZwm6Q24P4uin0BuDD9o30C+GJu23JJ9wNDgBOrHnBlHgZOljQZeBC4gOyLcB7wAnBPKtcCTE3dYgLOjYhXJF0PXC3pcOCUmkffjYj4W/pZLwAWkX3Z9+YM4HJJxwF3kNV/aUQskfRd4I8pMb4NnAw8VZ3o32NH4GxJ7encXwFWAuem38dg4Byyrr3jgIskTUplx5O9POUAst/v06luZWvGOjUFD11RA5JuJbv42uMLrmtJ2V1Cv4uI0WXHUg8krQ60RcTK9JfqBRExpuSwzGrKLQSzzEjgqtQKeAv415LjMas5txDMzAzwRWUzM0ucEMzMDHBCMDOzxBeVbcBIz5D8KS1+gOzBpcVpeY+IeKuUwMzqhC8q24CUnsJ+PSJ+UnYsZvXCXUY2oEk6UNL9aWTMyel5BLMByQnBBrI1yEb8nBARO5J1oX6l1IjMSuSEYANZC/BkRDySli8hG8DPbEByQjAzM8AJwQa2NmCUpC3TcucRas0GFCcEG8iWk41IO03SXLI3rl1Ybkhm5fFtp2ZmBriFYGZmiROCmZkBTghmZpY4IZiZGeCEYGZmiROCmZkBTghmZpb8f06eGPh7bAr4AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sample = dataset.test_df.sample(frac=0.01, random_state=100)\n",
+    "create_heatmap(nnp, sample, title=\"Neural Net\")\n",
+    "create_heatmap(linreg, sample, title=\"Linear Regression\")\n",
+    "create_heatmap(forest, sample, title=\"Random Forest\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Statistical Significance\n",
+    "The models were tested by training them multiple times and comparing the samples using a t-test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_and_test(n, model_constructor, config, train_df, test_df, save_path, override_start_year=None):\n",
+    "    \"\"\"\n",
+    "    Trains a model n times on each region and evaluates each model on each region.\n",
+    "    :param n: Number of times to train each model on each region.\n",
+    "    :param model_constructor: A function that returns a model.\n",
+    "    :param config: A dictionary of configuration parameters for each model type.\n",
+    "    :param train_df: The training data.\n",
+    "    :param test_df: The testing data.\n",
+    "    :param save_path: The path to save the results.\n",
+    "    :param override_start_year: If not None, overrides the start year of the test data on the ALL region.\n",
+    "        (This is currently only used for the random forest)\n",
+    "    \"\"\"\n",
+    "    if not Path(save_path).exists():\n",
+    "        with open(save_path, \"w\") as f:\n",
+    "            f.write(\"region,eval,mae,time\\n\")\n",
+    "    with open(save_path, \"a\") as f:\n",
+    "        # Iterate over all regions\n",
+    "        for train_region in constants.COUNTRY_DICT.keys():\n",
+    "            print(train_region)\n",
+    "            if train_region != \"ALL\":\n",
+    "                countries = constants.COUNTRY_DICT[train_region]\n",
+    "                idx = constants.COUNTRIES_DF[constants.COUNTRIES_DF[\"abbrevs\"].isin(countries)].index.values\n",
+    "                train_region_df = train_df[train_df[\"country\"].isin(idx)]\n",
+    "            else:\n",
+    "                train_region_df = train_df\n",
+    "            \n",
+    "            # n times for each region\n",
+    "            for i in tqdm(range(n)):\n",
+    "                model = model_constructor(**config)\n",
+    "                s = time.time()\n",
+    "                _ = model.fit(train_region_df, **config)\n",
+    "                e = time.time()\n",
+    "                # Evaluate on each region\n",
+    "                for test_region in constants.COUNTRY_DICT.keys():\n",
+    "                    if test_region != \"ALL\":\n",
+    "                        countries = constants.COUNTRY_DICT[test_region]\n",
+    "                        idx = constants.COUNTRIES_DF[constants.COUNTRIES_DF[\"abbrevs\"].isin(countries)].index.values\n",
+    "                        test_region_df = test_df[test_df[\"country\"].isin(idx)]\n",
+    "                    else:\n",
+    "                        test_region_df = test_df\n",
+    "                        if override_start_year:\n",
+    "                            test_region_df = test_region_df.loc[override_start_year:]\n",
+    "                    \n",
+    "                    mae = mean_absolute_error(model.predict(test_region_df), test_region_df[\"ELUC\"])\n",
+    "                    f.write(f\"{train_region},{test_region},{mae},{e - s}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_constructors = [NeuralNetPredictor, LinearRegressionPredictor, RandomForestPredictor]\n",
+    "configs = [nn_config, linreg_config, forest_config]\n",
+    "model_names = [\"neural_network\", \"linear_regression\", \"random_forest\"]\n",
+    "for model_constructor, config, model_name in zip(model_constructors, configs, model_names):\n",
+    "    override_start_year = None\n",
+    "    if model_name == \"random_forest\":\n",
+    "        override_start_year = 2002\n",
+    "    train_and_test(30, model_constructor, config, dataset.train_df, dataset.test_df, f\"experiments/{model_name}_eval.csv\", override_start_year=override_start_year)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "leaf",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/use_cases/eluc/experiments/predictor_experiments.ipynb
+++ b/use_cases/eluc/experiments/predictor_experiments.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +24,7 @@
     "from matplotlib.colors import LinearSegmentedColormap\n",
     "import seaborn as sns\n",
     "\n",
+    "from scipy.stats import ttest_1samp, ttest_ind\n",
     "from sklearn.metrics import mean_absolute_error\n",
     "\n",
     "from data.eluc_data import ELUCData\n",
@@ -395,6 +396,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate results:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -408,6 +416,153 @@
     "    if model_name == \"random_forest\":\n",
     "        override_start_year = 2002\n",
     "    train_and_test(30, model_constructor, config, dataset.train_df, dataset.test_df, f\"experiments/{model_name}_eval.csv\", override_start_year=override_start_year)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Load Results and Perform T-Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linreg_results = pd.read_csv(\"experiments/linear_regression_eval.csv\")\n",
+    "nn_results = pd.read_csv(\"experiments/neural_network_eval.csv\")\n",
+    "forest_results = pd.read_csv(\"experiments/random_forest_eval.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EU p-value forest < nn: 1.0\n",
+      "SA p-value forest < nn: 4.081372920256761e-96\n",
+      "US p-value forest < nn: 8.865504240014044e-41\n",
+      "ALL p-value forest < nn: 5.399007032681815e-49\n"
+     ]
+    }
+   ],
+   "source": [
+    "for region in constants.COUNTRY_DICT.keys():\n",
+    "    lr_region_results = linreg_results[(linreg_results[\"region\"] == region) & (linreg_results[\"eval\"] == region)] \n",
+    "    region_results = forest_results[(forest_results[\"region\"] == region) & (forest_results[\"eval\"] == region)]\n",
+    "    other_results = nn_results[(nn_results[\"region\"] == region) & (nn_results[\"eval\"] == region)]\n",
+    "    print(f\"{region} p-value forest < nn: {ttest_ind(region_results['mae'], other_results['mae'], alternative='less').pvalue}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create Table for Latex Paper\n",
+    "Creates a significance table comparing the different models trained on each region and then evaluated on each region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def table_results(self_name, self_results, other_results, linreg_results):\n",
+    "    \"\"\"\n",
+    "    Generates results table for the overleaf paper.\n",
+    "    Takes in one model's results and comparison model's results as well as linreg results.\n",
+    "    Checks if self model is better than linreg and if self model is better than other model.\n",
+    "    Prints by region.\n",
+    "    \"\"\"\n",
+    "    for region in constants.COUNTRY_DICT.keys():\n",
+    "        region_results = self_results[self_results[\"region\"] == region]\n",
+    "        row = f\"{self_name} ({region if region != 'ALL' else 'Global'}) & {region_results['time'].mean():.4f}\"\n",
+    "\n",
+    "        for eval_region in constants.COUNTRY_DICT.keys():\n",
+    "            # Other model significance test\n",
+    "            region_maes = region_results[region_results['eval'] == eval_region]['mae']\n",
+    "            other_maes = other_results[(other_results[\"region\"] == region) & (other_results[\"eval\"] == eval_region)][\"mae\"]\n",
+    "            other_pval = ttest_ind(region_maes, other_maes, alternative=\"less\").pvalue\n",
+    "\n",
+    "            # Linreg significance test\n",
+    "            linreg_mae = linreg_results[(linreg_results[\"region\"] == region) & (linreg_results[\"eval\"] == eval_region)].iloc[0][\"mae\"]\n",
+    "            linreg_pval = ttest_1samp(region_maes, linreg_mae, alternative=\"less\").pvalue\n",
+    "\n",
+    "            # Best method bolding\n",
+    "            bold = False\n",
+    "            if region == eval_region and region_maes.mean() < other_maes.mean():\n",
+    "                bold = True\n",
+    "\n",
+    "            row += f\" & ${region_maes.mean():.4f}\" if not bold else f\" & $\\\\textbf{{{region_maes.mean():.4f}}}\"\n",
+    "            if linreg_pval <= 0.01 or other_pval <= 0.01:\n",
+    "                row += \"^{\"\n",
+    "                if linreg_pval <= 0.01:\n",
+    "                    row += \"*\"\n",
+    "                if other_pval <= 0.01:\n",
+    "                    row += \"\\\\dag\"\n",
+    "                row += \"}\"\n",
+    "            row += \"$\"\n",
+    "        row += \"\\\\\\\\\"\n",
+    "        print(row)\n",
+    "    print(\"\\\\hline\")\n",
+    "\n",
+    "def generate_table(linreg_results, forest_results, nn_results):\n",
+    "    \"\"\"\n",
+    "    Prints LinReg results, then generates table for RF compared to LinReg and NN, then generates table for\n",
+    "    NN compared to LinReg and RF.\n",
+    "    \"\"\"\n",
+    "    # Linreg\n",
+    "    for region in constants.COUNTRY_DICT.keys():\n",
+    "        region_results = linreg_results[linreg_results[\"region\"] == region]\n",
+    "        row = f\"LinReg ({region if region != 'ALL' else 'Global'}) & {region_results.iloc[0]['time']:.4f}\"\n",
+    "        for eval_region in constants.COUNTRY_DICT.keys():\n",
+    "            row += f\" & {region_results[region_results['eval'] == eval_region].iloc[0]['mae']:.4f}\"\n",
+    "        row += \"\\\\\\\\\"\n",
+    "        print(row)\n",
+    "    print(\"\\\\hline\")\n",
+    "    # Forest\n",
+    "    table_results(\"RF\", forest_results, nn_results, linreg_results)\n",
+    "\n",
+    "    # NN\n",
+    "    table_results(\"NeuralNet\", nn_results, forest_results, linreg_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LinReg (EU) & 0.0847 & 0.0333 & 0.1712 & 0.1689 & 0.2061\\\\\n",
+      "LinReg (SA) & 0.5705 & 0.1360 & 0.1534 & 0.0623 & 0.1109\\\\\n",
+      "LinReg (US) & 0.3427 & 0.1399 & 0.1456 & 0.0351 & 0.0726\\\\\n",
+      "LinReg (Global) & 6.8722 & 0.1376 & 0.1503 & 0.0361 & 0.0742\\\\\n",
+      "\\hline\n",
+      "RF (EU) & 16.4930 & $0.0517$ & $0.2078^{\\dag}$ & $0.1532^{*\\dag}$ & $0.2196^{\\dag}$\\\\\n",
+      "RF (SA) & 206.4513 & $0.1333^{\\dag}$ & $\\textbf{0.0634}^{*\\dag}$ & $0.0757^{\\dag}$ & $0.1268^{\\dag}$\\\\\n",
+      "RF (US) & 101.7903 & $0.1424$ & $0.1844^{\\dag}$ & $\\textbf{0.0194}^{*\\dag}$ & $0.0922^{\\dag}$\\\\\n",
+      "RF (Global) & 422.2839 & $0.0348^{*\\dag}$ & $0.0669^{*\\dag}$ & $0.0202^{*\\dag}$ & $\\textbf{0.0398}^{*\\dag}$\\\\\n",
+      "\\hline\n",
+      "NeuralNet (EU) & 10.6497 & $\\textbf{0.0243}^{*\\dag}$ & $0.2663$ & $0.2817$ & $0.3329$\\\\\n",
+      "NeuralNet (SA) & 96.4302 & $0.2516$ & $0.0991^{*}$ & $0.5507$ & $0.4120$\\\\\n",
+      "NeuralNet (US) & 71.9760 & $0.1275^{*\\dag}$ & $0.2322$ & $0.0237^{*}$ & $0.1470$\\\\\n",
+      "NeuralNet (Global) & 1047.7100 & $0.0455^{*}$ & $0.1086^{*}$ & $0.0249^{*}$ & $0.0477^{*}$\\\\\n",
+      "\\hline\n"
+     ]
+    }
+   ],
+   "source": [
+    "generate_table(linreg_results, forest_results, nn_results)"
    ]
   }
  ],

--- a/use_cases/eluc/experiments/predictor_experiments.ipynb
+++ b/use_cases/eluc/experiments/predictor_experiments.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "results = nnp.fit(dataset.train_df[nn_config[\"features\"]], dataset.train_df[nn_config[\"label\"]], verbose=True)\n",
-    "nnp.save(\"experiments/trained_predictors/neural_network\")"
+    "nnp.save(\"predictors/neural_network/trained_models/experiment_nn\")"
    ]
   },
   {
@@ -109,7 +109,7 @@
     }
    ],
    "source": [
-    "nnp.load(\"experiments/trained_predictors/neural_network\")\n",
+    "nnp.load(\"predictors/neural_network/trained_models/experiment_nn\")\n",
     "print(f\"MAE Neural Net: {mean_absolute_error(dataset.test_df[nn_config['label']], nnp.predict(dataset.test_df[nn_config['features']]))}\")"
    ]
   },
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "linreg.fit(dataset.train_df[constants.DIFF_LAND_USE_COLS], dataset.train_df[\"ELUC\"])\n",
-    "linreg.save(\"experiments/trained_predictors/linear_regression\")"
+    "linreg.save(\"predictors/sklearn/trained_models/experiment_linreg\")"
    ]
   },
   {
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "linreg.load(\"experiments/trained_predictors/linear_regression\")\n",
+    "linreg.load(\"predictors/sklearn/trained_models/experiment_linreg\")\n",
     "print(f\"MAE Linear Regression: {mean_absolute_error(dataset.test_df['ELUC'], linreg.predict(dataset.test_df[constants.DIFF_LAND_USE_COLS]))}\")"
    ]
   },
@@ -191,7 +191,7 @@
     "# Note: The original paper trains from 1982 onwards but this is too slow and large for the\n",
     "# purpose of this example.\n",
     "forest.fit(dataset.train_df.loc[2002:][constants.NN_FEATS], dataset.train_df.loc[2002:][\"ELUC\"])\n",
-    "forest.save(\"experiments/trained_predictors/random_forest\")"
+    "forest.save(\"predictors/sklearn/trained_models/experiment_rf\")"
    ]
   },
   {
@@ -208,7 +208,7 @@
     }
    ],
    "source": [
-    "forest.load(\"experiments/trained_predictors/random_forest\")\n",
+    "forest.load(\"predictors/sklearn/trained_models/experiment_rf\")\n",
     "print(f\"MAE Random Forest: {mean_absolute_error(dataset.test_df['ELUC'], forest.predict(dataset.test_df[constants.NN_FEATS]))}\")"
    ]
   },

--- a/use_cases/eluc/predictors/demo_predictors.ipynb
+++ b/use_cases/eluc/predictors/demo_predictors.ipynb
@@ -115,9 +115,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nnp_save_path = \"predictors/neural_network/test\"\n",
-    "linreg_save_path = \"predictors/sklearn/linreg_test\"\n",
-    "rf_save_path = \"predictors/sklearn/rf_test\"\n",
+    "nnp_save_path = \"predictors/neural_network/trained_models/test\"\n",
+    "linreg_save_path = \"predictors/sklearn/trained_models/linreg_test\"\n",
+    "rf_save_path = \"predictors/sklearn/trained_models/rf_test\"\n",
     "\n",
     "nnp.save(nnp_save_path)\n",
     "linreg.save(linreg_save_path)\n",

--- a/use_cases/eluc/predictors/sklearn/sklearn_predictor.py
+++ b/use_cases/eluc/predictors/sklearn/sklearn_predictor.py
@@ -84,10 +84,26 @@ class LinearRegressionPredictor(SKLearnPredictor):
     
 class RandomForestPredictor(SKLearnPredictor):
     """
-    Simple linear regression predictor.
+    Simple random forest predictor.
     See SKLearnPredictor for more details.
+    Overrides save method in order to compress it.
     """
     def __init__(self, features=None, **kwargs):
         super().__init__(features)
         self.model = RandomForestRegressor(**kwargs)
+
+    def save(self, path: str, compression=0):
+        """
+        Overrides save method to compress file since Random Forests are extremely large.
+        :param path: path to folder to save model files.
+        """
+        save_path = Path(path)
+        save_path.mkdir(parents=True, exist_ok=True)
+        config = {
+            "features": self.features,
+            "label": self.label
+        }
+        with open(save_path / "config.json", "w", encoding="utf-8") as f:
+            json.dump(config, f)
+        joblib.dump(self.model, save_path / "model.joblib", compress=compression)
         


### PR DESCRIPTION
Updated random forest to be able to be compressed on save (since the one from the paper is over 30GB!!!)
Added predictor experiments notebook from before, modified to work with the current implementation.
Experiments added:
1. Heatmap
2. Significance Tests
3. Generate Latex for paper

Note: notebook is creating a smaller RF than before because it was crashing my computer to train the old full-size version.