### PR TITLE
Updated eluc data to not duplicate the year 2012

### DIFF
--- a/use_cases/eluc/data/eluc_data.py
+++ b/use_cases/eluc/data/eluc_data.py
@@ -152,8 +152,8 @@ class ELUCData(AbstractData):
         if countries:
             df = self.subset_countries(df, countries)
 
-        self.train_df = df.loc[start_year:test_year]
-        self.test_df = df.loc[test_year:end_year]
+        self.train_df = df.loc[start_year:test_year-1]
+        self.test_df = df.loc[test_year:end_year-1]
         
         self.encoder = ELUCEncoder(self.get_fields())
 
@@ -177,8 +177,8 @@ class RawELUCData(AbstractData):
         raw = self.import_data(path, update_path)
         df = self.da_to_df(raw, start_year, end_year, countries)
 
-        self.train_df = df.loc[start_year:test_year]
-        self.test_df = df.loc[test_year:end_year]
+        self.train_df = df.loc[start_year:test_year-1]
+        self.test_df = df.loc[test_year:end_year-1]
         
         self.encoder = ELUCEncoder(self.get_fields())
 
@@ -251,5 +251,3 @@ class RawELUCData(AbstractData):
         df = df.drop("mask", axis=1)
             
         return df
-
-    


### PR DESCRIPTION
I made a big mistake! Pandas indexing is end-inclusive so I was double counting the year 2012 when indexing df[1851:2012], df[2012:2022]. Interestingly enough it did not throw an error when I passed 2022 as the final year because it allows you to pass values out of the range of the index.