### PR TITLE
Fix distance calcuation in NSGA-II

### DIFF
--- a/use_cases/eluc/prescriptors/nsga2/nsga2_utils.py
+++ b/use_cases/eluc/prescriptors/nsga2/nsga2_utils.py
@@ -59,20 +59,24 @@ def fast_non_dominated_sort(candidates: list):
 
 def calculate_crowding_distance(front):
     """
-    Calculate crowding distance of each candidate in front.
+    Set crowding distance of each candidate in front.
     """
     n_objectives = len(front[0].metrics)
-    distances = [0 for _ in range(len(front))]
+    for c in front:
+        c.distance = 0
     for m in range(n_objectives):
-        sorted_indices = sorted(range(len(front)), key=lambda i: front[i].metrics[m])
-        obj_min = front[sorted_indices[0]].metrics[m]
-        obj_max = front[sorted_indices[-1]].metrics[m]
-        distances[0] = float('inf')
-        distances[-1] = float('inf')
-        for i in sorted_indices[1:-1]:
-            distances[i] += (front[i+1].metrics[m] - front[i-1].metrics[m]) / (obj_max - obj_min)
-
-    return distances
+        sorted_front = sorted(front, key=lambda candidate: candidate.metrics[m])
+        obj_min = sorted_front[0].metrics[m]
+        obj_max = sorted_front[-1].metrics[m]
+        sorted_front[0].distance = float('inf')
+        sorted_front[-1].distance = float('inf')
+        for i in range(1, len(sorted_front) - 1):
+            if obj_max != obj_min:
+                dist = sorted_front[i+1].metrics[m] - sorted_front[i-1].metrics[m]
+                sorted_front[i].distance += dist / (obj_max - obj_min)
+            # If all candidates have the same value, their distances are 0
+            else:
+                sorted_front[i].distance += 0
 
 def dominates(candidate1: Candidate, candidate2: Candidate):
     """

--- a/use_cases/eluc/prescriptors/nsga2/nsga2_utils.py
+++ b/use_cases/eluc/prescriptors/nsga2/nsga2_utils.py
@@ -62,8 +62,8 @@ def calculate_crowding_distance(front):
     Set crowding distance of each candidate in front.
     """
     n_objectives = len(front[0].metrics)
-    for c in front:
-        c.distance = 0
+    for candidate in front:
+        candidate.distance = 0
     for m in range(n_objectives):
         sorted_front = sorted(front, key=lambda candidate: candidate.metrics[m])
         obj_min = sorted_front[0].metrics[m]

--- a/use_cases/eluc/prescriptors/nsga2/nsga2_utils.py
+++ b/use_cases/eluc/prescriptors/nsga2/nsga2_utils.py
@@ -64,12 +64,12 @@ def calculate_crowding_distance(front):
     n_objectives = len(front[0].metrics)
     distances = [0 for _ in range(len(front))]
     for m in range(n_objectives):
-        front.sort(key=lambda candidate: candidate.metrics[m])
-        obj_min = front[0].metrics[m]
-        obj_max = front[-1].metrics[m]
+        sorted_indices = sorted(range(len(front)), key=lambda i: front[i].metrics[m])
+        obj_min = front[sorted_indices[0]].metrics[m]
+        obj_max = front[sorted_indices[-1]].metrics[m]
         distances[0] = float('inf')
         distances[-1] = float('inf')
-        for i in range(1, len(front) - 1):
+        for i in sorted_indices[1:-1]:
             distances[i] += (front[i+1].metrics[m] - front[i-1].metrics[m]) / (obj_max - obj_min)
 
     return distances

--- a/use_cases/eluc/prescriptors/nsga2/torch_prescriptor.py
+++ b/use_cases/eluc/prescriptors/nsga2/torch_prescriptor.py
@@ -145,9 +145,7 @@ class TorchPrescriptor(Prescriptor):
         for front in fronts:
             # Compute crowding distance here even though it's technically not necessary now
             # so that later we can sort by distance
-            crowding_distance = nsga2_utils.calculate_crowding_distance(front)
-            for candidate, distance in zip(front, crowding_distance):
-                candidate.distance = distance
+            nsga2_utils.calculate_crowding_distance(front)
             if len(parents) + len(front) > n_parents:  # If adding this front exceeds num_parents
                 front = sorted(front, key=lambda candidate: candidate.distance, reverse=True)
                 parents += front[:n_parents - len(parents)]

--- a/use_cases/eluc/tests/test_nsga2.py
+++ b/use_cases/eluc/tests/test_nsga2.py
@@ -77,9 +77,15 @@ class TestNSGA2Utils(unittest.TestCase):
                 dist1 = ((i + 1)**2 - (i - 1)**2) / 9
                 tgt_distances.append(dist0 + dist1)
 
-        distances = nsga2_utils.calculate_crowding_distance(front)
-        for dist, tgt in zip(distances, tgt_distances):
-            self.assertAlmostEqual(dist, tgt)
+        # Manually shuffle the front
+        shuffled_indices = [1, 3, 0, 2]
+        shuffled_front = [front[i] for i in shuffled_indices]
+        shuffled_tgts = [tgt_distances[i] for i in shuffled_indices]
+
+        # Assign crowding distances
+        nsga2_utils.calculate_crowding_distance(shuffled_front)
+        for candidate, tgt in zip(shuffled_front, shuffled_tgts):
+            self.assertAlmostEqual(candidate.distance, tgt)
 
 class TestTorchPrescriptor(unittest.TestCase):
     """

--- a/use_cases/eluc/tests/test_nsga2.py
+++ b/use_cases/eluc/tests/test_nsga2.py
@@ -13,6 +13,7 @@ from data.eluc_data import ELUCEncoder
 from predictors.sklearn.sklearn_predictor import LinearRegressionPredictor
 from prescriptors.nsga2.candidate import Candidate
 from prescriptors.nsga2.torch_prescriptor import TorchPrescriptor
+import prescriptors.nsga2.nsga2_utils as nsga2_utils
 
 def get_fields(df):
     """
@@ -53,6 +54,32 @@ def get_fields(df):
     }
 
     return fields
+
+class TestNSGA2Utils(unittest.TestCase):
+    """
+    Tests the NGSA-II utility functions.
+    """
+    def test_distance_calculation(self):
+        """
+        Tests the calculation of crowding distance.
+        """
+        # Create a dummy front
+        front = []
+        tgt_distances = []
+        for i in range(4):
+            dummy_candidate = Candidate(16, 16, 16)
+            dummy_candidate.metrics = [i*2, i**2]
+            front.append(dummy_candidate)
+            if i == 0 or i == 3:
+                tgt_distances.append(np.inf)
+            else:
+                dist0 = ((i + 1) * 2 - (i - 1) * 2) / 6
+                dist1 = ((i + 1)**2 - (i - 1)**2) / 9
+                tgt_distances.append(dist0 + dist1)
+
+        distances = nsga2_utils.calculate_crowding_distance(front)
+        for dist, tgt in zip(distances, tgt_distances):
+            self.assertAlmostEqual(dist, tgt)
 
 class TestTorchPrescriptor(unittest.TestCase):
     """


### PR DESCRIPTION
Distance calculation was being done wrong before! Was being done randomly since we weren't sorting the distance list. Copied distance calculation from merging experiment to work properly. We were still getting a good pareto because we had so many candidates and generations, but now we may do better than before or converge much faster.